### PR TITLE
Info-Overlay for Images/Videos

### DIFF
--- a/QuickLook.Installer/QuickLook.Installer.wixproj
+++ b/QuickLook.Installer/QuickLook.Installer.wixproj
@@ -50,7 +50,7 @@ powershell -file "$(SolutionDir)Scripts\pack-zip.ps1"</PostBuildEvent>
 
 robocopy "$(SolutionDir)Build\$(Configuration)" "$(SolutionDir)Build\Package" %2a.%2a /e /njh /njs /ndl /nfl /nc /ns /np /xf %2a.pdb /xf %2a.obj /xf %2a.ipdb /xf %2a.iobj /xf %2a.exp /xf %2a.lib /xf %2a.ilk /xf %2a.xml
 
-powershell -file "$(SolutionDir)Scripts\sign-package.ps1"
+REM powershell -file "$(SolutionDir)Scripts\sign-package.ps1"
 
 "$(WIX)bin\heat" dir "$(SolutionDir)Build\Package" -dr INSTALLFOLDER -cg QuickLookComponents -gg -g1 -sf -srd -sreg -var "var.PackageDir" -out "$(ProjectDir)C_QuickLookComponents.wxs"</PreBuildEvent>
   </PropertyGroup>

--- a/QuickLook.Native/QuickLook.Native32/QuickLook.Native32.vcxproj
+++ b/QuickLook.Native/QuickLook.Native32/QuickLook.Native32.vcxproj
@@ -47,10 +47,12 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
     <OutDir>$(SolutionDir)Build\$(Configuration)\</OutDir>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);c:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\atlmfc\include\</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
     <OutDir>$(SolutionDir)Build\$(Configuration)\</OutDir>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);c:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\atlmfc\include\</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/QuickLook.Native/QuickLook.Native64/QuickLook.Native64.vcxproj
+++ b/QuickLook.Native/QuickLook.Native64/QuickLook.Native64.vcxproj
@@ -67,9 +67,11 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <OutDir>$(SolutionDir)Build\$(Configuration)\</OutDir>
     <TargetExt>.dll</TargetExt>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);c:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\atlmfc\include\</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <OutDir>$(SolutionDir)Build\$(Configuration)\</OutDir>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);c:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\atlmfc\include\</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>

--- a/QuickLook.Plugin/QuickLook.Plugin.ArchiveViewer/Plugin.cs
+++ b/QuickLook.Plugin/QuickLook.Plugin.ArchiveViewer/Plugin.cs
@@ -51,6 +51,7 @@ namespace QuickLook.Plugin.ArchiveViewer
 
             context.ViewerContent = _panel;
             context.Title = $"{Path.GetFileName(path)}";
+            context.ShowOverlayInfo("");
 
             context.IsBusy = false;
         }

--- a/QuickLook.Plugin/QuickLook.Plugin.CsvViewer/Plugin.cs
+++ b/QuickLook.Plugin/QuickLook.Plugin.CsvViewer/Plugin.cs
@@ -47,6 +47,7 @@ namespace QuickLook.Plugin.CsvViewer
 
             context.ViewerContent = _panel;
             context.Title = $"{Path.GetFileName(path)}";
+            context.ShowOverlayInfo("");
             _panel.LoadFile(path);
 
             context.IsBusy = false;

--- a/QuickLook.Plugin/QuickLook.Plugin.HtmlViewer/Plugin.cs
+++ b/QuickLook.Plugin/QuickLook.Plugin.HtmlViewer/Plugin.cs
@@ -51,6 +51,7 @@ namespace QuickLook.Plugin.HtmlViewer
             _panel = new WebpagePanel();
             context.ViewerContent = _panel;
             context.Title = Path.IsPathRooted(path) ? Path.GetFileName(path) : path;
+            context.ShowOverlayInfo("");
 
             _panel.Navigate(path);
             _panel.Dispatcher.Invoke(() => { context.IsBusy = false; }, DispatcherPriority.Loaded);

--- a/QuickLook.Plugin/QuickLook.Plugin.IPreviewHandlers/Plugin.cs
+++ b/QuickLook.Plugin/QuickLook.Plugin.IPreviewHandlers/Plugin.cs
@@ -62,6 +62,7 @@ namespace QuickLook.Plugin.IPreviewHandlers
             _panel = new PreviewPanel();
             context.ViewerContent = _panel;
             context.Title = Path.GetFileName(path);
+            context.ShowOverlayInfo("");
 
             _panel.PreviewFile(path, context);
 

--- a/QuickLook.Plugin/QuickLook.Plugin.ImageViewer/Plugin.cs
+++ b/QuickLook.Plugin/QuickLook.Plugin.ImageViewer/Plugin.cs
@@ -21,6 +21,7 @@ using System.Linq;
 using System.Windows;
 using ImageMagick;
 using QuickLook.Plugin.ImageViewer.Exiv2;
+using System.Windows.Controls;
 
 namespace QuickLook.Plugin.ImageViewer
 {
@@ -70,6 +71,15 @@ namespace QuickLook.Plugin.ImageViewer
         {
             _ip = new ImagePanel(_meta);
 
+            var summary = _ip.Meta.GetSummary();
+            string s = "";
+            foreach (var item in summary)
+            {
+                s += String.Format("{0,-30}: ", item.Key.ToString());
+                s += String.Format("{0,-200}", item.Value.ToString());
+                s += "\n";
+            }
+            context.ShowOverlayInfo(s);
             context.ViewerContent = _ip;
             context.Title = _imageSize.IsEmpty
                 ? $"{Path.GetFileName(path)}"

--- a/QuickLook.Plugin/QuickLook.Plugin.MailViewer/Plugin.cs
+++ b/QuickLook.Plugin/QuickLook.Plugin.MailViewer/Plugin.cs
@@ -51,6 +51,7 @@ namespace QuickLook.Plugin.MailViewer
             _panel = new WebpagePanel();
             context.ViewerContent = _panel;
             context.Title = Path.GetFileName(path);
+            context.ShowOverlayInfo("");
 
             _panel.Navigate(ExtractMailBody(path));
             _panel.Dispatcher.Invoke(() => { context.IsBusy = false; }, DispatcherPriority.Loaded);

--- a/QuickLook.Plugin/QuickLook.Plugin.MarkdownViewer/Plugin.cs
+++ b/QuickLook.Plugin/QuickLook.Plugin.MarkdownViewer/Plugin.cs
@@ -50,6 +50,7 @@ namespace QuickLook.Plugin.MarkdownViewer
             _panel = new WebpagePanel();
             context.ViewerContent = _panel;
             context.Title = Path.GetFileName(path);
+            context.ShowOverlayInfo("");
 
             _panel.LoadHtml(GenerateMarkdownHtml(path));
             _panel.Dispatcher.Invoke(() => { context.IsBusy = false; }, DispatcherPriority.Loaded);

--- a/QuickLook.Plugin/QuickLook.Plugin.PDFViewer/Plugin.cs
+++ b/QuickLook.Plugin/QuickLook.Plugin.PDFViewer/Plugin.cs
@@ -63,6 +63,7 @@ namespace QuickLook.Plugin.PDFViewer
         {
             _pdfControl = new PdfViewerControl();
             context.ViewerContent = _pdfControl;
+            context.ShowOverlayInfo("");
 
             Exception exception = null;
 

--- a/QuickLook.Plugin/QuickLook.Plugin.TextViewer/Plugin.cs
+++ b/QuickLook.Plugin/QuickLook.Plugin.TextViewer/Plugin.cs
@@ -67,6 +67,7 @@ namespace QuickLook.Plugin.TextViewer
 
             context.ViewerContent = _tvp;
             context.Title = $"{Path.GetFileName(path)}";
+            context.ShowOverlayInfo("");
 
             context.IsBusy = false;
         }

--- a/QuickLook.Plugin/QuickLook.Plugin.VideoViewer/Plugin.cs
+++ b/QuickLook.Plugin/QuickLook.Plugin.VideoViewer/Plugin.cs
@@ -104,6 +104,7 @@ namespace QuickLook.Plugin.VideoViewer
             _vp = new ViewerPanel(context, probe.HasVideo());
 
             context.ViewerContent = _vp;
+            context.ShowOverlayInfo(probe.RawResult);
 
             _vp.mediaElement.MediaOpened += MediaElement_MediaOpened;
             _vp.LoadAndPlay(path);

--- a/QuickLook.Plugin/QuickLook.Plugin.VideoViewer/ViewerPanel.xaml
+++ b/QuickLook.Plugin/QuickLook.Plugin.VideoViewer/ViewerPanel.xaml
@@ -80,7 +80,6 @@
                 <TextBlock x:Name="metaTitle" Grid.Row="1" FontSize="22" Padding="3"
                            TextWrapping="Wrap"
                            LineHeight="28" MaxHeight="80" TextTrimming="CharacterEllipsis">
-                    ときめきポポロン♪
                 </TextBlock>
                 <TextBlock x:Name="metaArtists" Grid.Row="3" FontSize="14" Padding="3" TextTrimming="CharacterEllipsis"
                            Foreground="{DynamicResource WindowTextForeground}">
@@ -98,7 +97,7 @@
 
         <Grid x:Name="videoControlContainer" HorizontalAlignment="Stretch" VerticalAlignment="Bottom" Height="32">
             <Grid.Resources>
-                <Storyboard x:Key="ShowControlStoryboard" Completed="AutoHideViedoControlContainer">
+                <Storyboard x:Key="ShowControlStoryboard" Completed="AutoHideVideoControlContainer">
                     <DoubleAnimation
                         Storyboard.Target="{Binding Source={x:Reference videoControlContainer}}"
                         Storyboard.TargetProperty="Opacity" To="1" Duration="0:0:0.05" />

--- a/QuickLook.Plugin/QuickLook.Plugin.VideoViewer/ViewerPanel.xaml.cs
+++ b/QuickLook.Plugin/QuickLook.Plugin.VideoViewer/ViewerPanel.xaml.cs
@@ -53,8 +53,8 @@ namespace QuickLook.Plugin.VideoViewer
             // apply global theme
             Resources.MergedDictionaries[0].MergedDictionaries.Clear();
 
-            ShowViedoControlContainer(null, null);
-            viewerPanel.PreviewMouseMove += ShowViedoControlContainer;
+            ShowVideoControlContainer(null, null);
+            viewerPanel.PreviewMouseMove += ShowVideoControlContainer;
 
             //mediaElement.PropertyChanged += PlayerPropertyChanged;
             //mediaElement.StateChanged += PlayerStateChanged;
@@ -123,14 +123,14 @@ namespace QuickLook.Plugin.VideoViewer
 
         public event PropertyChangedEventHandler PropertyChanged;
 
-        private void ShowViedoControlContainer(object sender, MouseEventArgs e)
+        private void ShowVideoControlContainer(object sender, MouseEventArgs e)
         {
             var show = (Storyboard) videoControlContainer.FindResource("ShowControlStoryboard");
             if (videoControlContainer.Opacity == 0 || videoControlContainer.Opacity == 1)
                 show.Begin();
         }
 
-        private void AutoHideViedoControlContainer(object sender, EventArgs e)
+        private void AutoHideVideoControlContainer(object sender, EventArgs e)
         {
             if (!ShowVideo)
                 return;

--- a/QuickLook.Plugin/QuickLook.Plugin.VideoViewer/ffmpeg/FFprobe.cs
+++ b/QuickLook.Plugin/QuickLook.Plugin.VideoViewer/ffmpeg/FFprobe.cs
@@ -21,12 +21,30 @@ using System.IO;
 using System.Reflection;
 using System.Text;
 using System.Windows;
+using System.Windows.Documents;
 using System.Xml.XPath;
 
 namespace QuickLook.Plugin.VideoViewer.FFmpeg
 {
     internal class FFprobe
     {
+        private string _rawResult;
+        public string RawResult
+        {
+            get => _rawResult;
+            internal set
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    _rawResult = "";
+                }
+                else
+                {
+                    _rawResult = value;
+                }
+            }
+        }
+
         private static readonly string _probePath =
             Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "FFmpeg\\",
                 App.Is64Bit ? "x64\\" : "x86\\", "ffprobe.exe");
@@ -60,9 +78,12 @@ namespace QuickLook.Plugin.VideoViewer.FFmpeg
                 }
 
                 if (string.IsNullOrWhiteSpace(result))
+                {
                     return false;
+                }
 
                 ParseResult(result);
+                RawResult = XMLResultToText();
                 return true;
             }
             catch (Exception)
@@ -70,6 +91,139 @@ namespace QuickLook.Plugin.VideoViewer.FFmpeg
                 return false;
             }
         }
+
+        private string XMLResultToText()
+        {
+            string res = "";
+            try
+            {
+                XPathNavigator format = _infoNavigator.SelectSingleNode("/ffprobe/format");
+                res += "Format\n\n";
+                res += String.Format("{0,-30}: {1,-255}", "Filename", format.GetAttribute("filename", "").ToString());
+                res += "\n";
+                res += String.Format("{0,-30}: {1,-255}", "Format", format.GetAttribute("format_long_name", "").ToString());
+                res += "\n";
+                res += String.Format("{0,-30}: {1,-255}", "Duration", MicrosecondStringToTime(format.GetAttribute("duration", "").ToString()));
+                res += "\n";
+                res += String.Format("{0,-30}: {1,-255}", "Size", format.GetAttribute("size", "").ToString());
+                res += "\n";
+                res += String.Format("{0,-30}: {1,-255}", "Bitrate", BitrateStringToMBit(format.GetAttribute("bit_rate", "").ToString()));
+                res += "\n";
+                try
+                {
+                    res += String.Format("{0,-30}: {1,-255}", "Encoder", _infoNavigator?.SelectSingleNode("/ffprobe/format/tag[@key='encoder']/@value").ToString());
+                    res += "\n";
+                }
+                catch { }
+
+                XPathNodeIterator streamsIterator = _infoNavigator.Select("/ffprobe/streams/stream");
+                if (streamsIterator.Count > 0)
+                {
+                    foreach (XPathNavigator stream in streamsIterator)
+                    {
+                        res += "\n";
+                        string streamType = stream?.GetAttribute("codec_type", "").ToString();
+                        res += String.Format("Stream {0} ({1})", stream?.GetAttribute("index", "").ToString(), streamType);
+                        res += "\n";
+                        res += "\n";
+                        res += String.Format("{0,-30}: {1,-255}", "Codec", stream?.GetAttribute("codec_name", "").ToString());
+                        res += "\n";
+                        res += String.Format("{0,-30}: {1,-255}", "Codec (Long)", stream?.GetAttribute("codec_long_name", ""));
+                        res += "\n";
+                        res += String.Format("{0,-30}: {1,-255}", "Profile", stream?.GetAttribute("profile", ""));
+                        res += "\n";
+                        res += String.Format("{0,-30}: {1,-255}", "Codec Timebase", stream?.GetAttribute("codec_time_base", ""));
+                        res += "\n";
+                        res += String.Format("{0,-30}: {1,-255}", "Codec Tag", stream?.GetAttribute("codec_tag_string", ""));
+                        res += "\n";
+                        if (streamType == "audio")
+                        {
+                            res += String.Format("{0,-30}: {1,-255}", "Sample Format", stream?.GetAttribute("sample_fmt", ""));
+                            res += "\n";
+                            res += String.Format("{0,-30}: {1,-255}", "Sample Rate", stream?.GetAttribute("sample_rate", ""));
+                            res += "\n";
+                            res += String.Format("{0,-30}: {1,-255}", "Channels", stream?.GetAttribute("channels", ""));
+                            res += "\n";
+                            res += String.Format("{0,-30}: {1,-255}", "Channel Layout", stream?.GetAttribute("channel_layout", ""));
+                            res += "\n";
+                            res += String.Format("{0,-30}: {1,-255}", "Bits per sample", stream?.GetAttribute("bits_per_sample", ""));
+                            res += "\n";
+                            res += String.Format("{0,-30}: {1,-255}", "Duration", MicrosecondStringToTime(stream?.GetAttribute("duration", "")));
+                            res += "\n";
+                            res += String.Format("{0,-30}: {1,-255}", "Bitrate", BitrateStringToMBit(stream?.GetAttribute("bit_rate", "")));
+                            res += "\n";
+                            res += String.Format("{0,-30}: {1,-255}", "Max Bitrate", BitrateStringToMBit(stream?.GetAttribute("max_bit_rate", "")));
+                            res += "\n";
+                            res += String.Format("{0,-30}: {1,-255}", "Frames", stream?.GetAttribute("nb_frames", ""));
+                            res += "\n";
+                        }
+                        if (streamType == "video")
+                        {
+                            res += String.Format("{0,-30}: {1,-255}", "Width x Height", stream?.GetAttribute("coded_width", "") + " x " + stream?.GetAttribute("coded_height", ""));
+                            res += "\n";
+                            res += String.Format("{0,-30}: {1,-255}", "Aspect Ratio (Sample)", stream?.GetAttribute("sample_aspect_ratio", ""));
+                            res += "\n";
+                            res += String.Format("{0,-30}: {1,-255}", "Aspect Ration (Display)", stream?.GetAttribute("display_aspect_ratio", ""));
+                            res += "\n";
+                            res += String.Format("{0,-30}: {1,-255}", "Pix Format", stream?.GetAttribute("pix_fmt", ""));
+                            res += "\n";
+                            res += String.Format("{0,-30}: {1,-255}", "Level", stream?.GetAttribute("level", ""));
+                            res += "\n";
+                            res += String.Format("{0,-30}: {1,-255}", "Framerate", stream?.GetAttribute("r_frame_rate", ""));
+                            res += "\n";
+                            res += String.Format("{0,-30}: {1,-255}", "Framerate (avg)", stream?.GetAttribute("avg_frame_rate", ""));
+                            res += "\n";
+                            res += String.Format("{0,-30}: {1,-255}", "Timebase", stream?.GetAttribute("time_base", ""));
+                            res += "\n";
+                            res += String.Format("{0,-30}: {1,-255}", "Duration", MicrosecondStringToTime(stream?.GetAttribute("duration", "")));
+                            res += "\n";
+                            res += String.Format("{0,-30}: {1,-255}", "Bitrate", BitrateStringToMBit(stream?.GetAttribute("bit_rate", "")));
+                            res += "\n";
+                            res += String.Format("{0,-30}: {1,-255}", "Bits per sample", stream?.GetAttribute("bits_per_raw_sample", ""));
+                            res += "\n";
+                            res += String.Format("{0,-30}: {1,-255}", "Frames", stream?.GetAttribute("nb_frames", ""));
+                            res += "\n";
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                res += ex.Message;
+                return res;
+            }
+            return res;
+        }
+
+        private string MicrosecondStringToTime(string ms)
+        {
+            try
+            {
+                double d = Double.Parse(ms);
+                TimeSpan t = TimeSpan.FromMilliseconds(d * 1000); // 
+                return t.ToString();
+            }
+            catch
+            {
+                return "";
+            }
+        }
+
+        private string BitrateStringToMBit(string bitrate)
+        {
+            try
+            {
+                double d = Double.Parse(bitrate);
+                string mbps = (d / 1024.0 / 1024.0).ToString("N2");
+                return String.Format("{0} MBps ({1})", mbps, bitrate);
+            }
+            catch
+            {
+                return "";
+            }
+        }
+
+
 
         private void ParseResult(string result)
         {

--- a/QuickLook/App.xaml
+++ b/QuickLook/App.xaml
@@ -10,7 +10,8 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="Styles/ScrollBarStyleDictionary.xaml" />
             </ResourceDictionary.MergedDictionaries>
-            <FontFamily x:Key="SegoeMDL2">./Fonts/#Segoe MDL2 Assets</FontFamily>
+            <!--<FontFamily x:Key="SegoeMDL2">./Fonts/#Segoe MDL2 Assets</FontFamily>-->
+            <FontFamily x:Key="SegoeMDL2">Segoe MDL2 Assets</FontFamily>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/QuickLook/Plugin/ContextObject.cs
+++ b/QuickLook/Plugin/ContextObject.cs
@@ -21,6 +21,7 @@ using System.Globalization;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Windows;
+using System.Windows.Controls;
 using QuickLook.Annotations;
 using QuickLook.Helpers;
 
@@ -41,6 +42,7 @@ namespace QuickLook.Plugin
         private bool _titlebarOverlap;
         private bool _useDarkTheme;
         private object _viewerContent;
+        private object _viewerOverlayContent;
 
         /// <summary>
         ///     Get the viewer window.
@@ -69,6 +71,19 @@ namespace QuickLook.Plugin
             set
             {
                 _viewerContent = value;
+                OnPropertyChanged();
+            }
+        }
+
+        /// <summary>
+        ///     Get or set the viewer content control.
+        /// </summary>
+        public object ViewerOverlayContent
+        {
+            get => _viewerOverlayContent;
+            set
+            {
+                _viewerOverlayContent = value;
                 OnPropertyChanged();
             }
         }
@@ -252,6 +267,23 @@ namespace QuickLook.Plugin
             PreferredSize = new Size {Width = size.Width * ratio, Height = size.Height * ratio};
 
             return ratio;
+        }
+
+        public void ShowOverlayInfo(string infoText = "")
+        {
+            if (infoText != "")
+            {
+                //ViewerOverlayContent = new TextBlock()
+                //{
+                //    Text = infoText
+                //};
+                ViewerOverlayContent = infoText;
+            }
+            else
+            {
+                // possibly hide overlay when empty string is sent
+                ViewWindowManager.GetInstance().ShowAndHideInfo(show:false);
+            }
         }
 
         internal void Reset()

--- a/QuickLook/QuickLook.csproj
+++ b/QuickLook/QuickLook.csproj
@@ -86,6 +86,9 @@
     </AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Magick.NET-Q8-AnyCPU, Version=7.4.0.0, Culture=neutral, PublicKeyToken=2004825badfa91ec, processorArchitecture=MSIL">
+      <HintPath>..\packages\Magick.NET-Q8-AnyCPU.7.4.0\lib\net40\Magick.NET-Q8-AnyCPU.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.1-beta1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/QuickLook/Styles/MainWindowStyles.xaml
+++ b/QuickLook/Styles/MainWindowStyles.xaml
@@ -6,6 +6,8 @@
     <system:Double x:Key="MainWindowCaptionHeight">32</system:Double>
     <SolidColorBrush x:Key="MainWindowBackground" Color="#BBFAFAFA" />
     <SolidColorBrush x:Key="MainWindowBackgroundNoTransparent" Color="#FFFAFAFA" />
+    <SolidColorBrush x:Key="OverlayBackgroundSemiTransparent" Color="#77000000" />
+    <SolidColorBrush x:Key="OverlayTextForeground" Color="#FFFEFEFE" />
     <SolidColorBrush x:Key="WindowTextForeground" Color="#FF0E0E0E" />
     <SolidColorBrush x:Key="WindowTextForegroundAlternative" Color="#FF626262" />
     <SolidColorBrush x:Key="CaptionTextHoverBorder" Color="#FF3D3D3D" />

--- a/QuickLook/ViewWindowManager.cs
+++ b/QuickLook/ViewWindowManager.cs
@@ -42,6 +42,18 @@ namespace QuickLook
             StopFocusMonitor();
         }
 
+        public void ShowAndHideInfo(bool show=true)
+        {
+            if(_viewerWindow.containerOverlayFade.Visibility != Visibility.Visible && show==true)
+            {
+                _viewerWindow.containerOverlayFade.Visibility = Visibility.Visible;
+            }
+            else
+            {
+                _viewerWindow.containerOverlayFade.Visibility = Visibility.Collapsed;
+            }
+        }
+
         public void RunAndClosePreview()
         {
             if (_viewerWindow.Visibility != Visibility.Visible)

--- a/QuickLook/ViewerWindow.Properties.cs
+++ b/QuickLook/ViewerWindow.Properties.cs
@@ -42,6 +42,17 @@ namespace QuickLook
                 OnPropertyChanged();
             }
         }
+        private bool _showInfo;
+        internal bool ShowInfo
+        {
+            get => _showInfo;
+            set
+            {
+                _showInfo = value;
+                buttonInfo.Tag = "Info";
+                OnPropertyChanged();
+            }
+        }
         public IViewer Plugin { get; private set; }
         public ContextObject ContextObject { get; private set; }
         public event PropertyChangedEventHandler PropertyChanged;

--- a/QuickLook/ViewerWindow.xaml
+++ b/QuickLook/ViewerWindow.xaml
@@ -137,6 +137,27 @@
                             </Style>
                         </Button.Style>
                     </Button>
+                    <Button DockPanel.Dock="Left" x:Name="buttonInfo" Tag="Auto">
+                        <Button.Resources>
+                            <Grid x:Key="ContentInfo">
+                                <TextBlock>&#xE946;</TextBlock>
+                                <TextBlock>&#xF167;</TextBlock>
+                            </Grid>
+                        </Button.Resources>
+                        <Button.Style>
+                            <Style TargetType="Button" BasedOn="{StaticResource CaptionButtonStyle}">
+                                <Setter Property="Content" Value="&#xE946;" />
+                                <Style.Triggers>
+                                    <Trigger Property="Tag" Value="Auto">
+                                        <Setter Property="Content" Value="&#xE946;" />
+                                    </Trigger>
+                                    <Trigger Property="Tag" Value="Pin">
+                                        <Setter Property="Content" Value="{StaticResource ContentInfo}" />
+                                    </Trigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Button.Style>
+                    </Button>
                     <Button DockPanel.Dock="Left" x:Name="buttonShare" Style="{StaticResource CaptionButtonStyle}"
                             Content="&#xE72D;" />
                     <Grid x:Name="titleArea" Background="Transparent">
@@ -149,9 +170,28 @@
             <DockPanel x:Name="containerPanel" ZIndex="80">
                 <Grid DockPanel.Dock="Top" Height="{StaticResource MainWindowCaptionHeight}"
                       Visibility="{Binding ContextObject.TitlebarOverlap, ElementName=mainWindow, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
-                <ContentControl x:Name="container"
-                                Foreground="{DynamicResource WindowTextForeground}"
-                                Content="{Binding ContextObject.ViewerContent, ElementName=mainWindow}" />
+                <Grid>
+                    <ContentControl x:Name="container"
+                                    Grid.Row="0"
+                                    Grid.Column="0"
+                                    Panel.ZIndex="0"
+                                    Foreground="{DynamicResource WindowTextForeground}"
+                                    Content="{Binding ContextObject.ViewerContent, ElementName=mainWindow}" />
+                    <Border x:Name="containerOverlayFade"
+                            Grid.Row="0"
+                            Grid.Column="0"
+                            Panel.ZIndex="100"
+                            Background="{DynamicResource OverlayBackgroundSemiTransparent}"
+                            Padding="20,40,20,20"
+                            Visibility="Collapsed" >
+                        <ScrollViewer>
+                            <TextBlock x:Name="containerOverlayContent"
+                                       Foreground="{DynamicResource OverlayTextForeground}"
+                                       Text="{Binding ContextObject.ViewerOverlayContent, ElementName=mainWindow}"
+                                       FontFamily="Consolas, Courier" />
+                        </ScrollViewer>
+                    </Border>
+                </Grid>
                 <DockPanel.Style>
                     <Style TargetType="{x:Type DockPanel}">
                         <Setter Property="Visibility" Value="Visible" />

--- a/QuickLook/ViewerWindow.xaml.cs
+++ b/QuickLook/ViewerWindow.xaml.cs
@@ -63,6 +63,14 @@ namespace QuickLook
                 ViewWindowManager.GetInstance().ForgetCurrentWindow();
             };
 
+            buttonInfo.Click += (sender, e) =>
+            {
+                if (ShowInfo)
+                    return;
+
+                ViewWindowManager.GetInstance().ShowAndHideInfo();
+            };
+
             buttonCloseWindow.Click += (sender, e) =>
             {
                 if (Pinned)

--- a/QuickLook/packages.config
+++ b/QuickLook/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Magick.NET-Q8-AnyCPU" version="7.4.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="11.0.1-beta1" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
Added an info overlay (and icon in toolbar) to show file info based on exiv2 and ffprobe data.
Also fixed two typos...

![2018-02-07 19_32_42-](https://user-images.githubusercontent.com/6930367/35934387-b5bcbd42-0c3d-11e8-96e4-bdbe59a94c5b.png)