### PR TITLE
Updated differences url in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Get it from one of the following sources:
   * Installer or portable archive of the stable version from [GitHub Release](https://github.com/QL-Win/QuickLook/releases) 
   * Nightly builds from [AppVeyor](https://ci.appveyor.com/project/xupefei/quicklook/build/artifacts)
 
-[What are the differences between `.msi`, `.zip`, Nightly and Store versions?](https://github.com/QL-Win/QuickLook/wiki/Difference-Between-Distributions)
+[What are the differences between `.msi`, `.zip`, Nightly and Store versions?](https://github.com/QL-Win/QuickLook/wiki/Differences-Between-Distributions)
 
 
 ### Typical usecase


### PR DESCRIPTION
The differences url was pointing to `Difference-Between-Distributions` instead of `Differences-Between-Distributions` (you forgot the s in differences is all)