### PR TITLE
Fix syntax highlighting for batch files

### DIFF
--- a/QuickLook.Plugin/QuickLook.Plugin.TextViewer/Syntax/Batch.xshd
+++ b/QuickLook.Plugin/QuickLook.Plugin.TextViewer/Syntax/Batch.xshd
@@ -10,7 +10,7 @@ hello@exr.be
 https://github.com/ei
 -->
 
-<SyntaxDefinition name="Batch" extensions="*.bat;*.cmd">
+<SyntaxDefinition name="Batch" extensions=".bat;.cmd">
 
     <Environment>
         <Default color="Black" bgcolor="#FFFFFF"/>


### PR DESCRIPTION
This fixes the syntax highlighting for batch files.
The extension identifier was wrongly formatted.