### PR TITLE
为简化第三方软件调用，在第一个命令行参数（路径）前增加一个“|”实现两种控制方式

### DIFF
--- a/QuickLook/App.xaml.cs
+++ b/QuickLook/App.xaml.cs
@@ -67,11 +67,26 @@ namespace QuickLook
 
             EnsureFirstInstance();
 
+            string path = null;
+            bool bToInvoke = false;
+
+            if (e.Args.Any())
+            {
+                path = e.Args.First();
+                bToInvoke = path.StartsWith("|");
+                if (bToInvoke) path = path.Substring(1);
+
+                if(path != "" && !Directory.Exists(path) && !File.Exists(path))
+                    path = null;
+            }            
+
             if (!_isFirstInstance)
             {
                 // second instance: preview this file
-                if (e.Args.Any() && (Directory.Exists(e.Args.First()) || File.Exists(e.Args.First())))
-                    RemoteCallShowPreview(e);
+                if(path == "")
+                    PipeServerManager.SendMessage(PipeMessages.Close);
+                else if (path != null)
+                    PipeServerManager.SendMessage(bToInvoke? PipeMessages.Invoke : PipeMessages.Toggle, path);
                 // second instance: duplicate
                 else
                     MessageBox.Show(TranslationHelper.Get("APP_SECOND_TEXT"), TranslationHelper.Get("APP_SECOND"),
@@ -85,8 +100,8 @@ namespace QuickLook
             RunListener(e);
 
             // first instance: run and preview this file
-            if (e.Args.Any() && (Directory.Exists(e.Args.First()) || File.Exists(e.Args.First())))
-                RemoteCallShowPreview(e);
+            if (!string.IsNullOrEmpty(path))
+                PipeServerManager.SendMessage(PipeMessages.Toggle, path);
         }
 
         private void CheckUpdate()


### PR DESCRIPTION
为简化第三方软件调用：

1. 在第一个命令行参数（路径）前增加一个“|”确保预览窗口不会“意外”关闭（无论之前预览的文件具体是什么）。如：`QuickLook.exe "|README.MD"`。

2. 如果第一个参数只是''|"，就直接关闭任何已打开的预览窗口。如：`QuickLook.exe "|"`。