### PR TITLE
ArchiveViewer: Add support for more archive file types

### DIFF
--- a/QuickLook.Plugin/QuickLook.Plugin.ArchiveViewer/Plugin.cs
+++ b/QuickLook.Plugin/QuickLook.Plugin.ArchiveViewer/Plugin.cs
@@ -26,7 +26,7 @@ namespace QuickLook.Plugin.ArchiveViewer
     public class Plugin : IViewer
     {
         private static readonly string[] Extensions =
-            {".rar", ".zip", ".tar", ".tgz", ".gz", ".bz2", ".lz", ".xz", ".7z"};
+            {".rar", ".zip", ".tar", ".tgz", ".gz", ".bz2", ".lz", ".xz", ".7z", ".jar", ".crx"};
 
         private ArchiveInfoPanel _panel;
 


### PR DESCRIPTION
Resolve #772, while adding another archive file type.

Add support for `.jar` and `.crx` files, treated the same as `.zip` files.

*(This would bring convenience to Java programmers and Chrome extension developers)*