### PR TITLE
ImageViewer: add .jfif format support

### DIFF
--- a/QuickLook.Plugin/QuickLook.Plugin.ImageViewer/Plugin.cs
+++ b/QuickLook.Plugin/QuickLook.Plugin.ImageViewer/Plugin.cs
@@ -50,7 +50,7 @@ namespace QuickLook.Plugin.ImageViewer
                 new KeyValuePair<string[], Type>(new[] {".gif"},
                     typeof(GifProvider)));
             AnimatedImage.AnimatedImage.Providers.Add(
-                new KeyValuePair<string[], Type>(new[] {".bmp", ".jpg", ".jpeg", ".tif", ".tiff"},
+                new KeyValuePair<string[], Type>(new[] {".bmp", ".jpg", ".jpeg", ".jfif", ".tif", ".tiff"},
                     typeof(NativeProvider)));
             AnimatedImage.AnimatedImage.Providers.Add(
                 new KeyValuePair<string[], Type>(new[] {"*"},


### PR DESCRIPTION
While previewing `.jfif` image files, it will fall to `ImageMagickProvider` in the current implementation, which seems doesn't be able to handle such format very well. The `NativeProvider` instead, can handle `.jfif` format images very well, so this patch adds `.jfif` to `NativeProvider`.

Before this patch:

![image](https://user-images.githubusercontent.com/10095765/109411829-a8b47a00-79df-11eb-9049-9e6a084a2146.png)

After this patch:

![image](https://user-images.githubusercontent.com/10095765/109411841-bb2eb380-79df-11eb-89d0-f73101735cd7.png)
