### PR TITLE
Update spanish localization

### DIFF
--- a/QuickLook.Plugin/QuickLook.Plugin.TextViewer/Translations.config
+++ b/QuickLook.Plugin/QuickLook.Plugin.TextViewer/Translations.config
@@ -14,9 +14,11 @@
     <Editor_Copy>Copy</Editor_Copy>
     <Editor_SelectAll>Select All</Editor_SelectAll>
   </en>
-  <es-ES>
+  <es>
     <Editor_FontFamily>Consolas</Editor_FontFamily>
-  </es-ES>
+    <Editor_Copy>Copiar</Editor_Copy>
+    <Editor_SelectAll>Seleccionar Todo</Editor_SelectAll>
+  </es>
   <fr-FR>
     <Editor_FontFamily>Consolas</Editor_FontFamily>
   </fr-FR>

--- a/QuickLook/Translations.config
+++ b/QuickLook/Translations.config
@@ -193,7 +193,7 @@
     <Update_NoUpdate>Está usando la última versión.</Update_NoUpdate>
     <Update_Found>QuickLook {0} está disponible. Haga clic aquí para abrir la página de descarga.</Update_Found>
     <Update_Error>Ocurrió un error al buscar actualizaciones: {0}</Update_Error>
-    <InfoPanel_LastModified>Última modificación a las {0}</InfoPanel_LastModified>
+    <InfoPanel_LastModified>Última modificación el {0}</InfoPanel_LastModified>
     <InfoPanel_DriveSize>Capacidad {0}, {1} disponible</InfoPanel_DriveSize>
     <InfoPanel_Folder>{0} carpeta</InfoPanel_Folder>
     <InfoPanel_Folders>{0} carpetas</InfoPanel_Folders>

--- a/QuickLook/Translations.config
+++ b/QuickLook/Translations.config
@@ -175,20 +175,23 @@
     <InfoPanel_Files>{0} files</InfoPanel_Files>
     <InfoPanel_FolderAndFile>({0} and {1})</InfoPanel_FolderAndFile>
   </en>
-  <es-ES>
+  <es>
     <UI_FontFamily>Segoe UI</UI_FontFamily>
     <APP_START>QuickLook está funcionando en segundo plano.</APP_START>
     <APP_SECOND>QuickLook ya está funcionando en segundo plano</APP_SECOND>
+    <APP_SECOND_TEXT>QuickLook permite la previsualización rápida de ciertos tipos de archivos pulsando la barra espaciadora mientras este está resaltado.</APP_SECOND_TEXT>
+    <APP_PATH_NOT_WRITABLE>No se puede escribir en la ruta "{0}". Por favor, compruebe si tiene suficientes permisos.</APP_PATH_NOT_WRITABLE>
     <MW_BrowseFolder>Explorar {0}</MW_BrowseFolder>
     <MW_Open>Abrir {0}</MW_Open>
     <MW_OpenWith>Abrir con {0}</MW_OpenWith>
     <MW_Run>Iniciar {0}</MW_Run>
     <Icon_RunAtStartup>Iniciar con el &amp;sistema</Icon_RunAtStartup>
     <Icon_ToolTip>QuickLook v{0}</Icon_ToolTip>
-    <Icon_CheckUpdate>Buscar &amp;actualizaciones...</Icon_CheckUpdate>
+    <Icon_CheckUpdate>Buscar &amp;Actualizaciones...</Icon_CheckUpdate>
+    <Icon_GetPlugin>Buscar nuevos &amp;Plugins...</Icon_GetPlugin>
     <Icon_Quit>&amp;Salir</Icon_Quit>
-    <Update_NoUpdate>Estás usando la última versión.</Update_NoUpdate>
-    <Update_Found>QuickLook {0} está disponible. Haz clic aquí para abrir la página de descarga.</Update_Found>
+    <Update_NoUpdate>Está usando la última versión.</Update_NoUpdate>
+    <Update_Found>QuickLook {0} está disponible. Haga clic aquí para abrir la página de descarga.</Update_Found>
     <Update_Error>Ocurrió un error al buscar actualizaciones: {0}</Update_Error>
     <InfoPanel_LastModified>Última modificación a las {0}</InfoPanel_LastModified>
     <InfoPanel_DriveSize>Capacidad {0}, {1} disponible</InfoPanel_DriveSize>
@@ -197,7 +200,7 @@
     <InfoPanel_File>{0} archivo</InfoPanel_File>
     <InfoPanel_Files>{0} archivos</InfoPanel_Files>
     <InfoPanel_FolderAndFile>({0} y {1})</InfoPanel_FolderAndFile>
-  </es-ES>
+  </es>
   <fr-FR>
     <UI_FontFamily>Segoe UI</UI_FontFamily>
     <APP_START>QuickLook s'exécute en tâche de fond.</APP_START>


### PR DESCRIPTION
I'm not a developer, so I just removed the "-ES" part like the guide said, since the localization didn't show up when system language was latin american spanish. Some others have that, but I don't know if it's ok to remove them.

Is there any file for the tooltips in the preview window? I don't think I've seen them here.