### PR TITLE
Change AllowDarkTheme handling

### DIFF
--- a/QuickLook.Plugin/QuickLook.Plugin.TextViewer/Plugin.cs
+++ b/QuickLook.Plugin/QuickLook.Plugin.TextViewer/Plugin.cs
@@ -22,6 +22,7 @@ using System.Linq;
 using System.Reflection;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Media;
 using System.Xml;
 using ICSharpCode.AvalonEdit;
 using ICSharpCode.AvalonEdit.Highlighting;
@@ -149,6 +150,18 @@ namespace QuickLook.Plugin.TextViewer
             var darkThemeAllowed = SettingHelper.Get("AllowDarkTheme", false, "QuickLook.Plugin.TextViewer");
             var isDark = darkThemeAllowed && OSThemeHelper.AppsUseDarkTheme();
             tvp.HighlightingManager = isDark ? _hlmDark : _hlmLight;
+            if (isDark)
+            {
+                tvp.Background = Brushes.Transparent;
+                tvp.SetResourceReference(Control.ForegroundProperty, "WindowTextForeground");
+            }
+            else
+            {
+                // if os dark mode, but not AllowDarkTheme, make background light
+                tvp.Background = OSThemeHelper.AppsUseDarkTheme()
+                    ? new SolidColorBrush(Color.FromArgb(150, 255, 255, 255))
+                    : Brushes.Transparent;
+            }
         }
     }
 }

--- a/QuickLook.Plugin/QuickLook.Plugin.TextViewer/TextViewerPanel.cs
+++ b/QuickLook.Plugin/QuickLook.Plugin.TextViewer/TextViewerPanel.cs
@@ -45,9 +45,6 @@ namespace QuickLook.Plugin.TextViewer
         {
             _context = context;
 
-            Background = OSThemeHelper.AppsUseDarkTheme()
-                ? new SolidColorBrush(Color.FromArgb(150, 255, 255, 255))
-                : Brushes.Transparent;
             FontSize = 14;
             ShowLineNumbers = true;
             WordWrap = true;


### PR DESCRIPTION
Addresses https://github.com/QL-Win/QuickLook/issues/1232

In Textviewer when OS is in dark mode and AllowDarkTheme is enabled in config file use dark background and light text (no syntax highlighting).

With AllowDarkTheme disabled (default) use light background and light mode syntax highlighting.
