### PR TITLE
Update for commic archive file types.

### DIFF
--- a/QuickLook.Plugin/QuickLook.Plugin.ArchiveViewer/Plugin.cs
+++ b/QuickLook.Plugin/QuickLook.Plugin.ArchiveViewer/Plugin.cs
@@ -26,7 +26,7 @@ namespace QuickLook.Plugin.ArchiveViewer
     public class Plugin : IViewer
     {
         private static readonly string[] Extensions =
-            {".rar", ".zip", ".tar", ".tgz", ".gz", ".bz2", ".lz", ".xz", ".7z", ".jar", ".crx", ".nupkg"};
+            {".rar", ".zip", ".tar", ".tgz", ".gz", ".bz2", ".lz", ".xz", ".7z", ".jar", ".crx", ".nupkg", ".cb7", ".cbr", ".cbt", ".cbz"};
 
         private ArchiveInfoPanel _panel;
 


### PR DESCRIPTION
Comic book archive is not a distinct file format. It is a filename extension naming convention. The filename extension indicates the archive type used: .cb7 → 7z
.cbr → RAR
.cbt → TAR
.cbz → ZIP