### PR TITLE
add scoop installation route

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ I am aware that several alternatives are already available on the Internet (e.g.
 Get it from one of the following sources:
 
   * Microsoft Store (Windows 10 users only, no preview in open/save-dialogs available) <a href="https://www.microsoft.com/store/apps/9nv4bs3l1h4s?ocid=badge" target="_blank"><img src="https://developer.microsoft.com/store/badges/images/English_get_L.png" height="22px" alt="Store Link" /></a> 
-  * Installer or portable archive of the stable version from [GitHub Release](https://github.com/QL-Win/QuickLook/releases) 
+  * Installer or portable archive of the stable version from [GitHub Release](https://github.com/QL-Win/QuickLook/releases)
+  * Using [Scoop](https://scoop.sh/): `scoop install quicklook`
   * Nightly builds from [AppVeyor](https://ci.appveyor.com/project/xupefei/quicklook/build/artifacts)
 
 [What are the differences between `.msi`, `.zip`, Nightly and Store versions?](https://github.com/QL-Win/QuickLook/wiki/Differences-Between-Distributions)


### PR DESCRIPTION
i accidentily stumbled over it by just trying to run `scoop install quicklook` and it worked so I'd include it in the readme