### PR TITLE
Added WinGet as an installation method to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Get it from one of the following sources:
   * Microsoft Store (Windows 10 users only, no preview in open/save-dialogs available) <a href="https://www.microsoft.com/store/apps/9nv4bs3l1h4s?ocid=badge" target="_blank"><img src="https://developer.microsoft.com/store/badges/images/English_get_L.png" height="22px" alt="Store Link" /></a> 
   * Installer or portable archive of the stable version from [GitHub Release](https://github.com/QL-Win/QuickLook/releases) 
   * Nightly builds from [AppVeyor](https://ci.appveyor.com/project/xupefei/quicklook/build/artifacts)
+  * Use WinGet
+```powershell
+winget install QL-Win.QuickLook
+```
 
 [What are the differences between `.msi`, `.zip`, Nightly and Store versions?](https://github.com/QL-Win/QuickLook/wiki/Differences-Between-Distributions)
 


### PR DESCRIPTION
I don't think winget users will not search for the application, but I thought it's better to clarify all installation methods.