### PR TITLE
Add .ino extension to C++ syntax highlighting

### DIFF
--- a/QuickLook.Plugin/QuickLook.Plugin.TextViewer/Syntax/Light/C++.xshd
+++ b/QuickLook.Plugin/QuickLook.Plugin.TextViewer/Syntax/Light/C++.xshd
@@ -10,7 +10,7 @@ hello@exr.be
 https://github.com/ei
 -->
 
-<SyntaxDefinition name="C++" extensions=".c;.h;.cc;.C;.cpp;.cxx;.hpp">
+<SyntaxDefinition name="C++" extensions=".c;.h;.cc;.C;.cpp;.cxx;.hpp;.ino">
 
     <Environment> 
         <Default color="Black" bgcolor="#FFFFFF"/>


### PR DESCRIPTION
The `.ino` extension is used by Arduino IDE and uses C++. This PR adds syntax highlighting for this extension.