### PR TITLE
Fix for Everything v1.5(a). Also supports v1.4 side by side.

### DIFF
--- a/QuickLook.Native/QuickLook.Native32/Everything.h
+++ b/QuickLook.Native/QuickLook.Native32/Everything.h
@@ -15,11 +15,16 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#define EVERYTHING_IPC_HIDDEN_WIN_CLASS			L"EVERYTHING_RESULT_LIST_FOCUS"
+#define EVERYTHING_IPC_WINDOW_CLASS				L"EVERYTHING"
+#define EVERYTHING_IPC_COPY_TO_CLIPBOARD		41007
+
 #pragma once
 class Everything
 {
 public:
 	static void GetSelected(PWCHAR buffer);
+	static bool MatchClass(PWCHAR classBuffer);
 
 private:
 	static void backupClipboard();

--- a/QuickLook.Native/QuickLook.Native32/Shell32.cpp
+++ b/QuickLook.Native/QuickLook.Native32/Shell32.cpp
@@ -40,7 +40,7 @@ Shell32::FocusedWindowType Shell32::GetFocusedWindowType()
 	{
 		return DOPUS;
 	}
-	if (wcscmp(classBuffer, L"EVERYTHING") == 0 || wcscmp(classBuffer, L"EVERYTHING_SHELL_EXECUTE") == 0)
+ 	if (Everything::MatchClass(classBuffer))
 	{
 		return EVERYTHING;
 	}

--- a/QuickLook/NativeMethods/QuickLook.cs
+++ b/QuickLook/NativeMethods/QuickLook.cs
@@ -103,7 +103,12 @@ namespace QuickLook.NativeMethods
             thread.SetApartmentState(ApartmentState.STA);
             thread.Start();
             thread.Join();
-            return ResolveShortcut(sb?.ToString() ?? string.Empty);
+            if(sb.Length > 2 && sb[0].Equals('"') && sb[sb.Length-1].Equals('"'))
+            {
+                // We got a quoted string which breaks ResolveShortcut
+                sb = sb.Replace("\"", "", 0, 1).Replace("\"", "", sb.Length-1, 1);
+            }
+            return ResolveShortcut(sb?.ToString() ?? String.Empty);
         }
 
         private static string ResolveShortcut(string path)


### PR DESCRIPTION
1. Fix for Everything v1.5(a). Uses the new hidden window access instead of clipboard.
2. Turning off alpha_instance flag is no longer necessary. Putting it back to default helps.
3. Supports both v1.5 and v1.4. Earlier version is supported through clipboard  as before. 
4. Fixes a bug which crashes QuickLook when the path returned by client program is quoted.