### PR TITLE
Implement modern message box

### DIFF
--- a/QuickLook/App.xaml
+++ b/QuickLook/App.xaml
@@ -1,14 +1,20 @@
-﻿<Application x:Class="QuickLook.App"
+<Application x:Class="QuickLook.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:QuickLook"
+             xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+             xmlns:vio="http://schemas.lepo.co/wpfui/2022/xaml/violeta"
              Startup="Application_Startup"
              Exit="App_OnExit"
              ShutdownMode="OnExplicitShutdown">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="/QuickLook.Common;component/Styles/ScrollBarStyleDictionary.xaml" />
+                <ResourceDictionary Source="/QuickLook.Common;component/Styles/ScrollBarStyleDictionary.xaml"/>
+                <ui:ThemesDictionary />
+                <ui:ControlsDictionary/>
+                <vio:ThemesDictionary />
+                <vio:ControlsDictionary/>
             </ResourceDictionary.MergedDictionaries>
             <FontFamily x:Key="SegoeMDL2">./Fonts/#Segoe MDL2 Assets</FontFamily>
         </ResourceDictionary>

--- a/QuickLook/App.xaml.cs
+++ b/QuickLook/App.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 Paddy Xu
+// Copyright © 2017 Paddy Xu
 // 
 // This file is part of QuickLook program.
 // 
@@ -24,6 +24,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using QuickLook.Common.Helpers;
 using QuickLook.Helpers;
+using Wpf.Ui.Violeta.Appearance;
 
 namespace QuickLook
 {
@@ -50,8 +51,15 @@ namespace QuickLook
         {
             AppDomain.CurrentDomain.UnhandledException += (sender, args) =>
             {
-                ProcessHelper.WriteLog(((Exception) args.ExceptionObject).ToString());
+                ProcessHelper.WriteLog(((Exception)args.ExceptionObject).ToString());
             };
+
+            bool modernMessageBox = SettingHelper.Get("ModernMessageBox", true, "QuickLook");
+            // Initialize MessageBox patching
+            if (modernMessageBox) MessageBoxPatcher.Initialize();
+
+            // Set initial theme based on system settings
+            ThemeManager.Apply(ThemeManager.GetSystemTheme());
 
             base.OnStartup(e);
         }

--- a/QuickLook/Helpers/MessageBoxPatcher.cs
+++ b/QuickLook/Helpers/MessageBoxPatcher.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Diagnostics;
+using System.Windows;
+using HarmonyLib;
+using WindowsMessageBox = System.Windows.MessageBox;
+using VioletaMessageBox = Wpf.Ui.Violeta.Controls.MessageBox;
+
+namespace QuickLook.Helpers
+{
+    /// <summary>
+    /// Provides a helper class for patching MessageBox.Show method calls.
+    /// </summary>
+    public static class MessageBoxPatcher
+    {
+        private static readonly Harmony Harmony = new("com.quicklook.messagebox.patch");
+        private static readonly Type OriginalType = typeof(WindowsMessageBox);
+
+        /// <summary>
+        /// Defines all MessageBox.Show method overloads to be patched:
+        /// 1. Show(string messageBoxText)
+        /// 2. Show(string messageBoxText, string caption)
+        /// 3. Show(string messageBoxText, string caption, MessageBoxButton button)
+        /// 4. Show(string messageBoxText, string caption, MessageBoxButton button, MessageBoxImage icon)
+        /// 5. Show(Window owner, string messageBoxText, string caption, MessageBoxButton button, MessageBoxImage icon)
+        /// </summary>
+        private static readonly (string Name, Type[] Parameters)[] ShowMethods =
+        {
+            ("Show", [typeof(string)]),
+            ("Show", [typeof(string), typeof(string)]),
+            ("Show", [typeof(string), typeof(string), typeof(MessageBoxButton)]),
+            ("Show", [typeof(string), typeof(string), typeof(MessageBoxButton), typeof(MessageBoxImage)]),
+            ("Show", [typeof(Window), typeof(string), typeof(string), typeof(MessageBoxButton), typeof(MessageBoxImage)])
+        };
+
+        /// <summary>
+        /// Initializes the MessageBox patch by applying Harmony patches to the MessageBox.Show method overloads.
+        /// </summary>
+        public static void Initialize()
+        {
+            try
+            {
+                // Iterate over each MessageBox.Show method overload and apply the patch
+                foreach (var (name, parameters) in ShowMethods)
+                {
+                    var method = OriginalType.GetMethod(name, parameters);
+                    if (method != null)
+                    {
+                        Harmony.Patch(method, new HarmonyMethod(typeof(MessageBoxPatches), nameof(MessageBoxPatches.Prefix)));
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                // Log any errors that occur during patch initialization
+                Debug.WriteLine($"Failed to patch MessageBox: {ex}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Provides a patch for the MessageBox.Show method overloads.
+    /// </summary>
+    public static class MessageBoxPatches
+    {
+        /// <summary>
+        /// Prefix patch for the MessageBox.Show method overloads.
+        /// </summary>
+        /// <param name="__result">The result of the MessageBox.Show method call.</param>
+        /// <param name="__args">The arguments passed to the MessageBox.Show method call.</param>
+        /// <returns>True to skip the original method call, false to run the original method call.</returns>
+        public static bool Prefix(ref MessageBoxResult __result, object[] __args)
+        {
+            try
+            {
+                // Map each Windows MessageBox.Show overload to its Violeta equivalent
+                __result = __args.Length switch
+                {
+                    // Show(string messageBoxText)
+                    1 => VioletaMessageBox.Show(
+                        (string)__args[0]),
+
+                    // Show(string messageBoxText, string caption)
+                    2 => VioletaMessageBox.Show(
+                        (string)__args[0],
+                        (string)__args[1]),
+
+                    // Show(string messageBoxText, string caption, MessageBoxButton button)
+                    3 => VioletaMessageBox.Show(
+                        (string)__args[0],
+                        (string)__args[1],
+                        (MessageBoxButton)__args[2]),
+
+                    // Show(string messageBoxText, string caption, MessageBoxButton button, MessageBoxImage icon)
+                    4 => VioletaMessageBox.Show(
+                        (string)__args[0],
+                        (string)__args[1],
+                        (MessageBoxButton)__args[2],
+                        (MessageBoxImage)__args[3]),
+
+                    // Show(Window owner, string messageBoxText, string caption, MessageBoxButton button, MessageBoxImage icon)
+                    5 => VioletaMessageBox.Show(
+                        (string)__args[1], // Skip Window parameter
+                        (string)__args[2],
+                        (MessageBoxButton)__args[3],
+                        (MessageBoxImage)__args[4]),
+
+                    _ => throw new ArgumentException($"Unexpected number of arguments: {__args.Length}")
+                };
+
+                // Skip the original method call
+                return false;
+            }
+            catch (Exception ex)
+            {
+                // Log any errors that occur during patch execution
+                Debug.WriteLine($"Error in MessageBox patch: {ex}");
+                // Run the original method call on error
+                return true;
+            }
+        }
+    }
+}

--- a/QuickLook/QuickLook.csproj
+++ b/QuickLook/QuickLook.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
@@ -96,6 +96,8 @@
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="System.Runtime.WindowsRuntime" Version="4.7.0" />
 		<PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.122" />
+		<PackageReference Include="WPF-UI.Violeta" Version="3.0.5.26" />
+		<PackageReference Include="Lib.Harmony" Version="2.2.2" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
#### Features
- Replaces the outdated-looking standard `System.Windows.MessageBox` with [Wpf.Ui.Violeta.Controls.MessageBox](https://github.com/emako/wpfui.violeta).
- Uses [Harmony](https://github.com/pardeike/Harmony) to automatically patch usage, requiring no modifications to plugins.
- You can disable the modern message box by adding `<ModernMessageBox>False</ModernMessageBox>` to `<Data folder>/QuickLook.config` (defaults to enabled).

#### Screenshots
![image](https://github.com/user-attachments/assets/06d24e75-eccf-47ee-b85d-a935ff43248f)
