### PR TITLE
Implement Windows block detection and automatic fix

### DIFF
--- a/QuickLook/PluginManager.cs
+++ b/QuickLook/PluginManager.cs
@@ -102,18 +102,7 @@ namespace QuickLook
                                 // 0x80131515: ERROR_ASSEMBLY_FILE_BLOCKED - Windows blocked the assembly due to security policy
                                 catch (FileLoadException ex) when (ex.HResult == unchecked((int)0x80131515) && SettingHelper.IsPortableVersion())
                                 {
-                                    MessageBox.Show(
-                                        "Windows has blocked the plugins.\n\n" +
-                                        "To fix this, please follow these steps:\n" +
-                                        "1. Right-click the downloaded QuickLook zip file and select 'Properties'\n" +
-                                        "2. At the bottom of the Properties window, check 'Unblock'\n" +
-                                        "3. Click 'Apply' and 'OK'\n" +
-                                        "4. Extract the zip file again\n\n" +
-                                        "QuickLook will now close. Please launch it from the unblocked folder.",
-                                        "Security Block Detected",
-                                        MessageBoxButton.OK,
-                                        MessageBoxImage.Error);
-                                    throw;
+                                    if (!HandleSecurityBlockedException()) throw;
                                 }
                                 catch (Exception ex)
                                 {
@@ -152,6 +141,101 @@ namespace QuickLook
                     ProcessHelper.WriteLog(e.ToString());
                 }
             });
+        }
+
+        /// <summary>
+        /// Handles the case when Windows has blocked plugin files due to security policy.
+        /// Attempts automatic unblock first, then shows manual instructions if that fails.
+        /// </summary>
+        /// <returns>
+        /// <para>true if automatic unblock succeeded and app is restarting.</para>
+        /// <para>false if manual intervention is needed and exception should be thrown.</para>
+        /// </returns>
+        private static bool HandleSecurityBlockedException()
+        {
+            var triedUnblock = SettingHelper.Get("TriedUnblock", false);
+            if (!triedUnblock)
+            {
+                SettingHelper.Set("TriedUnblock", true);
+                if (TryUnblockFilesAndRestart()) return true;
+            }
+
+            // Show manual unblock instructions if automatic unblock failed or was already attempted
+            MessageBox.Show(
+                "Windows has blocked the plugins.\n\n" +
+                "To fix this, please follow these steps:\n" +
+                "1. Right-click the downloaded QuickLook zip file and select 'Properties'\n" +
+                "2. At the bottom of the Properties window, check 'Unblock'\n" +
+                "3. Click 'Apply' and 'OK'\n" +
+                "4. Extract the zip file again\n\n" +
+                "QuickLook will now close. Please launch it from the unblocked folder.",
+                "Security Block Detected",
+                MessageBoxButton.OK,
+                MessageBoxImage.Error);
+
+            return false;
+        }
+
+        /// <summary>
+        /// Attempts to automatically unblock all files in the application directory using PowerShell's Unblock-File cmdlet.
+        /// If successful, restarts the application to apply the changes.
+        /// </summary>
+        /// <returns>
+        /// <para>true if the unblock command succeeded and application restart was initiated.</para>
+        /// <para>false if the unblock command failed, in which case manual unblock instructions should be shown.</para>
+        /// </returns>
+        private static bool TryUnblockFilesAndRestart()
+        {
+            ProcessHelper.WriteLog("Attempting automatic unblock of plugins...");
+
+            try
+            {
+                var rootDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+                if (rootDir != null)
+                {
+                    // Create and start PowerShell process
+                    var startInfo = new ProcessStartInfo
+                    {
+                        FileName = "powershell.exe",
+                        Arguments = $"-NoProfile -ExecutionPolicy Bypass -Command \"Get-ChildItem '{rootDir}' -Recurse | Unblock-File\"",
+                        UseShellExecute = false,
+                        RedirectStandardOutput = true,
+                        RedirectStandardError = true,
+                        CreateNoWindow = true
+                    };
+
+                    using (var process = Process.Start(startInfo))
+                    {
+                        if (process != null)
+                        {
+                            process.WaitForExit();
+                            var output = process.StandardOutput.ReadToEnd();
+                            var error = process.StandardError.ReadToEnd();
+
+                            if (!string.IsNullOrEmpty(error))
+                                ProcessHelper.WriteLog($"PowerShell unblock output error: {error}");
+                            if (!string.IsNullOrEmpty(output))
+                                ProcessHelper.WriteLog($"PowerShell unblock output: {output}");
+                        }
+                    }
+                }
+
+                MessageBox.Show(
+                    "QuickLook has detected that Windows blocked the plugins, and has attempted to unblock them.\n\n" +
+                    "The application will now restart to check if the unblocking was successful.",
+                    "Security Unblock Attempt",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Information);
+
+                // Restart the application using TrayIconManager
+                TrayIconManager.GetInstance().Restart(forced: true);
+                return true;
+            }
+            catch (Exception unblockEx)
+            {
+                ProcessHelper.WriteLog($"Failed to perform automatic unblock: {unblockEx}");
+                return false;
+            }
         }
     }
 }

--- a/QuickLook/PluginManager.cs
+++ b/QuickLook/PluginManager.cs
@@ -85,64 +85,56 @@ namespace QuickLook
 
             var failedPlugins = new List<(string Plugin, Exception Error)>();
 
-            try
-            {
-                Directory.GetFiles(folder, "QuickLook.Plugin.*.dll",
-                        SearchOption.AllDirectories)
-                    .ToList()
-                    .ForEach(
-                        lib =>
+            Directory.GetFiles(folder, "QuickLook.Plugin.*.dll",
+                    SearchOption.AllDirectories)
+                .ToList()
+                .ForEach(
+                    lib =>
+                            {
+                                try
                                 {
-                                    try
-                                    {
-                                        (from t in Assembly.LoadFrom(lib).GetExportedTypes()
-                                         where !t.IsInterface && !t.IsAbstract
-                                         where typeof(IViewer).IsAssignableFrom(t)
-                                         select t).ToList()
-                                        .ForEach(type => LoadedPlugins.Add(type.CreateInstance<IViewer>()));
-                                    }
-                                    catch (FileLoadException ex) when (ex.Message.Contains("0x80131515") && SettingHelper.IsPortableVersion())
-                                    {
-                                        MessageBox.Show(
-                                            "Windows has blocked the plugins.\n\n" +
-                                            "To fix this, please follow these steps:\n" +
-                                            "1. Right-click the downloaded QuickLook zip file and select 'Properties'\n" +
-                                            "2. At the bottom of the Properties window, check 'Unblock'\n" +
-                                            "3. Click 'Apply' and 'OK'\n" +
-                                            "4. Extract the zip file again\n\n" +
-                                            "QuickLook will now close. Please launch it from the unblocked folder.",
-                                            "Security Block Detected",
-                                            MessageBoxButton.OK,
-                                            MessageBoxImage.Error);
-                                        throw;
-                                    }
-                                    catch (Exception ex)
-                                    {
-                                        // Log the error
-                                        ProcessHelper.WriteLog($"Failed to load plugin {Path.GetFileName(lib)}: {ex}");
-                                        failedPlugins.Add((Path.GetFileName(lib), ex));
-                                    }
-                                });
+                                    (from t in Assembly.LoadFrom(lib).GetExportedTypes()
+                                     where !t.IsInterface && !t.IsAbstract
+                                     where typeof(IViewer).IsAssignableFrom(t)
+                                     select t).ToList()
+                                    .ForEach(type => LoadedPlugins.Add(type.CreateInstance<IViewer>()));
+                                }
+                                catch (FileLoadException ex) when (ex.Message.Contains("0x80131515") && SettingHelper.IsPortableVersion())
+                                {
+                                    MessageBox.Show(
+                                        "Windows has blocked the plugins.\n\n" +
+                                        "To fix this, please follow these steps:\n" +
+                                        "1. Right-click the downloaded QuickLook zip file and select 'Properties'\n" +
+                                        "2. At the bottom of the Properties window, check 'Unblock'\n" +
+                                        "3. Click 'Apply' and 'OK'\n" +
+                                        "4. Extract the zip file again\n\n" +
+                                        "QuickLook will now close. Please launch it from the unblocked folder.",
+                                        "Security Block Detected",
+                                        MessageBoxButton.OK,
+                                        MessageBoxImage.Error);
+                                    throw;
+                                }
+                                catch (Exception ex)
+                                {
+                                    // Log the error
+                                    ProcessHelper.WriteLog($"Failed to load plugin {Path.GetFileName(lib)}: {ex}");
+                                    failedPlugins.Add((Path.GetFileName(lib), ex));
+                                }
+                            });
 
-                LoadedPlugins = LoadedPlugins.OrderByDescending(i => i.Priority).ToList();
+            LoadedPlugins = LoadedPlugins.OrderByDescending(i => i.Priority).ToList();
 
-                // If any plugins failed to load, show a message box with the details
-                if (failedPlugins.Any())
-                {
-                    var message = "The following plugins failed to load:\n\n" +
-                        string.Join("\n", failedPlugins.Select(f => $"• {f.Plugin}"));
-
-                    MessageBox.Show(
-                        message,
-                        "Some Plugins Failed to Load",
-                        MessageBoxButton.OK,
-                        MessageBoxImage.Warning);
-                }
-            }
-            catch (Exception ex)
+            // If any plugins failed to load, show a message box with the details
+            if (failedPlugins.Any())
             {
-                ProcessHelper.WriteLog(ex.ToString());
-                throw;
+                var message = "The following plugins failed to load:\n\n" +
+                    string.Join("\n", failedPlugins.Select(f => $"• {f.Plugin}"));
+
+                MessageBox.Show(
+                    message,
+                    "Some Plugins Failed to Load",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Warning);
             }
         }
 

--- a/QuickLook/PluginManager.cs
+++ b/QuickLook/PluginManager.cs
@@ -99,7 +99,8 @@ namespace QuickLook
                                      select t).ToList()
                                     .ForEach(type => LoadedPlugins.Add(type.CreateInstance<IViewer>()));
                                 }
-                                catch (FileLoadException ex) when (ex.Message.Contains("0x80131515") && SettingHelper.IsPortableVersion())
+                                // 0x80131515: ERROR_ASSEMBLY_FILE_BLOCKED - Windows blocked the assembly due to security policy
+                                catch (FileLoadException ex) when (ex.HResult == unchecked((int)0x80131515) && SettingHelper.IsPortableVersion())
                                 {
                                     MessageBox.Show(
                                         "Windows has blocked the plugins.\n\n" +


### PR DESCRIPTION
#### Features
- Automatically fixes the very common issue of Windows blocking the portable version zip from working.
- If the automatic fix fails, gives the user clear instructions on how to fix the issue, instead of silently exiting.
- Handle plugins that fail to load, allowing QuickLook to continue running without them.

#### How to test
1. Build this PR version to get portable version.
2. Upload the .zip to my simple web app [File Download Simulator](https://kamildev.github.io/file-download-simulator/) ([source](https://github.com/KamilDev/file-download-simulator)) to simulate downloading from online (just creates local blob URL and triggers the download).
3. Right click on downloaded zip file -> Properties. You should see it now contains "Unblock" option. Don't do anything.
4. Extract the zip using default Windows zip tool (using a tool like 7-zip may fix the block automatically).
5. When running QuickLook.exe, you should get the following message box:

![image](https://github.com/user-attachments/assets/f49999e2-a3f3-4ec3-a237-3f66c8c51fd1)

The application should restart and work as normal.
If it fails to automatically unblock, it will show the following message:

![Screenshot 2024-12-07 135034](https://github.com/user-attachments/assets/746c92e4-30ed-4e49-9bc2-e5d0c5b8784b)

After following the instructions, and launching QuickLook.exe from the unblocked folder, it should work as normal.