### PR TITLE
Fix ArchiveViewer

### DIFF
--- a/QuickLook/App.config
+++ b/QuickLook/App.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>


### PR DESCRIPTION
#### Changes
- Add `bindingRedirect` so that SharpCompress can find the correct version of `System.Runtime.CompilerServices.Unsafe`

Solves the following error from occurring:
```
Exception thrown: 'System.IO.FileNotFoundException' in SharpCompress.dll
System.IO.FileNotFoundException: Could not load file or assembly 'System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies. The system cannot find the file specified.
File name: 'System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
   at System.Span`1.Create(T[] array, Int32 start)
   at SharpCompress.Common.Zip.Headers.ZipFileEntry.LoadExtra(Byte[] extra)
   at SharpCompress.Common.Zip.Headers.DirectoryEntryHeader.Read(BinaryReader reader)
   at SharpCompress.Common.Zip.ZipHeaderFactory.ReadHeader(UInt32 headerBytes, BinaryReader reader, Boolean zip64)
   at SharpCompress.Common.Zip.SeekableZipHeaderFactory.<ReadSeekableHeader>d__5.MoveNext()
   at SharpCompress.Archives.Zip.ZipArchive.<LoadEntries>d__17.MoveNext()
   at SharpCompress.LazyReadOnlyCollection`1.LazyLoader.MoveNext()
   at QuickLook.Plugin.ArchiveViewer.ArchiveInfoPanel.LoadItemsFromArchive(String path) in C:\Users\Kamil\Dev\Fork\QuickLook\QuickLook.Plugin\QuickLook.Plugin.ArchiveViewer\ArchiveInfoPanel.xaml.cs:line 165
   at QuickLook.Plugin.ArchiveViewer.ArchiveInfoPanel.<>c__DisplayClass13_0.<BeginLoadArchive>b__0() in C:\Users\Kamil\Dev\Fork\QuickLook\QuickLook.Plugin\QuickLook.Plugin.ArchiveViewer\ArchiveInfoPanel.xaml.cs:line 89
```