### PR TITLE
Fix the issue where certain remote desktop software may generate drivers with unknown device types, causing null values in the values obtained by GetGPUNames, which leads to program crash during startup

### DIFF
--- a/QuickLook/NativeMethods/WMI.cs
+++ b/QuickLook/NativeMethods/WMI.cs
@@ -33,7 +33,8 @@ internal static class WMI
             List<string> names = [];
 
             foreach (var obj in searcher.Get())
-                names.Add(obj["Name"] as string);
+                if (obj["Name"] is string name)
+                    names.Add(name);
 
             return names;
         }
@@ -49,6 +50,7 @@ internal static class WMI
         {
             Debug.WriteLine($"General exception caught: {e.Message}");
         }
+
         return [];
     }
 }


### PR DESCRIPTION
Fix the issue where certain remote desktop software may generate drivers with unknown device types, causing null values in the values obtained by GetGPUNames, which leads to program crash during startup.

![image](https://github.com/user-attachments/assets/8a5b85cb-fecd-4a13-932a-d662d20c50b6)

dmp info:
```
STACK_TEXT:  
0000005f`3679b2f8 00007ffd`e069b30a QuickLook!QuickLook.Helpers.SystemHelper+<>c.<IsGPUInBlacklist>b__0_0+0x1a
0000005f`3679b300 00007ffd`8f0853bf System_Core_ni!System.Linq.Enumerable.Any[[System.__Canon, mscorlib]]+0xaf
0000005f`3679b370 00007ffd`e0695e3f QuickLook!QuickLook.App..cctor+0x18f


STACK_COMMAND:  !C:\ProgramData\Dbg\sym\SOS_AMD64_AMD64_4.8.9290.00.dll\67214BCA9a4000\SOS_AMD64_AMD64_4.8.9290.00.dll.pe 0x24532e8dbe8 ; ** Pseudo Context ** ManagedPseudo ** Value: ffffffff ** ; kb

SYMBOL_NAME:  QuickLook!QuickLook.Helpers.SystemHelper+<>c.<IsGPUInBlacklist>b__0_0+1a

MODULE_NAME: QuickLook

IMAGE_NAME:  QuickLook.exe

FAILURE_BUCKET_ID:  CLR_EXCEPTION_System.NullReferenceException_80004003_QuickLook.exe!QuickLook.Helpers.SystemHelper+__c._IsGPUInBlacklist_b__0_0
```