### PR TITLE
Add Reload + Customizatio

### DIFF
--- a/QuickLook/Translations.config
+++ b/QuickLook/Translations.config
@@ -175,6 +175,7 @@
     <MW_OpenWithMenu>Öffnen mit ...</MW_OpenWithMenu>
     <MW_Run>{0} ausführen</MW_Run>
     <MW_Share>Freigeben</MW_Share>
+    <MW_Reload>Reload</MW_Reload>
     <Icon_RunAtStartup>Beim Systemstart &amp;ausführen</Icon_RunAtStartup>
     <Icon_ToolTip>QuickLook v{0}</Icon_ToolTip>
     <Icon_CheckUpdate>Nach &amp;Updates suchen</Icon_CheckUpdate>
@@ -208,6 +209,7 @@
     <MW_OpenWithMenu>Open With Menu</MW_OpenWithMenu>
     <MW_Run>Run {0}</MW_Run>
     <MW_Share>Share</MW_Share>
+    <MW_Reload>Reload</MW_Reload>
     <Icon_RunAtStartup>Run at &amp;Startup</Icon_RunAtStartup>
     <Icon_ToolTip>QuickLook v{0}</Icon_ToolTip>
     <Icon_CheckUpdate>Check for &amp;Updates...</Icon_CheckUpdate>
@@ -241,6 +243,7 @@
     <MW_OpenWithMenu>Abrir Con Menu</MW_OpenWithMenu>
     <MW_Run>Iniciar {0}</MW_Run>
     <MW_Share>Compartir</MW_Share>
+    <MW_Reload>Reload</MW_Reload>
     <Icon_RunAtStartup>Iniciar con el &amp;sistema</Icon_RunAtStartup>
     <Icon_ToolTip>QuickLook v{0}</Icon_ToolTip>
     <Icon_CheckUpdate>Buscar &amp;Actualizaciones...</Icon_CheckUpdate>
@@ -328,6 +331,7 @@
     <MW_OpenWithMenu>メニューから選択して開く</MW_OpenWithMenu>
     <MW_Run>{0} を起動</MW_Run>
     <MW_Share>シェア</MW_Share>
+    <MW_Reload>Reload</MW_Reload>
     <Icon_RunAtStartup>スタートアップ時に起動</Icon_RunAtStartup>
     <Icon_ToolTip>QuickLook v{0}</Icon_ToolTip>
     <Icon_CheckUpdate>更新を確認する... (&amp;U)</Icon_CheckUpdate>
@@ -411,6 +415,7 @@
     <MW_OpenWith>Otwórz w {0}</MW_OpenWith>
     <MW_Run>Uruchom {0}</MW_Run>
     <MW_Share>Udostępnij</MW_Share>
+    <MW_Reload>Reload</MW_Reload>
     <Icon_RunAtStartup>Uruchamiaj automatycznie z systemem</Icon_RunAtStartup>
     <Icon_ToolTip>QuickLook v{0}</Icon_ToolTip>
     <Icon_CheckUpdate>Sprawdź &amp;aktualizacje...</Icon_CheckUpdate>
@@ -443,6 +448,7 @@
     <MW_OpenWithMenu>Menu abrir com</MW_OpenWithMenu>
     <MW_Run>Executar {0}</MW_Run>
     <MW_Share>Compartilhar</MW_Share>
+    <MW_Reload>Reload</MW_Reload>
     <Icon_RunAtStartup>Executar na &amp;Inicialização</Icon_RunAtStartup>
     <Icon_ToolTip>QuickLook v{0}</Icon_ToolTip>
     <Icon_CheckUpdate>Procurar por &amp;Atualizações...</Icon_CheckUpdate>
@@ -499,6 +505,7 @@
     <MW_StayTop>Поверх всех окон</MW_StayTop>
     <MW_PreventClosing>Закрепить</MW_PreventClosing>
     <MW_Share>Поделиться</MW_Share>
+    <MW_Reload>Reload</MW_Reload>
     <Icon_RunAtStartup>Автозапуск</Icon_RunAtStartup>
     <Icon_ToolTip>QuickLook v{0}</Icon_ToolTip>
     <Icon_CheckUpdate>Проверить &amp;обновления…</Icon_CheckUpdate>
@@ -558,6 +565,7 @@
     <MW_OpenWithMenu>Відкрити за допомогою меню</MW_OpenWithMenu>
     <MW_Run>Запустити {0}</MW_Run>
     <MW_Share>Поширити</MW_Share>
+    <MW_Reload>Reload</MW_Reload>
     <Icon_RunAtStartup>Запускати під час &amp;старту</Icon_RunAtStartup>
     <Icon_ToolTip>QuickLook v{0}</Icon_ToolTip>
     <Icon_CheckUpdate>Перевірити наявність &amp;оновлення…</Icon_CheckUpdate>
@@ -616,6 +624,7 @@
     <MW_OpenWithMenu>从菜单选择打开</MW_OpenWithMenu>
     <MW_Run>运行 {0}</MW_Run>
     <MW_Share>分享</MW_Share>
+    <MW_Reload>Reload</MW_Reload>
     <Icon_RunAtStartup>启动时自动运行 (&amp;S)</Icon_RunAtStartup>
     <Icon_ToolTip>QuickLook v{0}</Icon_ToolTip>
     <Icon_CheckUpdate>检查更新... (&amp;U)</Icon_CheckUpdate>
@@ -649,6 +658,7 @@
     <MW_OpenWithMenu>從選單選擇開啟</MW_OpenWithMenu>
     <MW_Run>執行 {0}</MW_Run>
     <MW_Share>分享</MW_Share>
+    <MW_Reload>Reload</MW_Reload>
     <Icon_RunAtStartup>系統啟動時自動執行 (&amp;S)</Icon_RunAtStartup>
     <Icon_ToolTip>QuickLook v{0}</Icon_ToolTip>
     <Icon_CheckUpdate>檢查更新... (&amp;U)</Icon_CheckUpdate>

--- a/QuickLook/ViewWindowManager.cs
+++ b/QuickLook/ViewWindowManager.cs
@@ -189,6 +189,16 @@ internal class ViewWindowManager : IDisposable
         }
     }
 
+    public void ReloadPreview()
+    {
+        if (!_viewerWindow.IsVisible || string.IsNullOrEmpty(_invokedPath))
+            return;
+
+        var matchedPlugin = PluginManager.GetInstance().FindMatch(_invokedPath);
+
+        BeginShowNewWindow(_invokedPath, matchedPlugin);
+    }
+
     private void BeginShowNewWindow(string path, IViewer matchedPlugin)
     {
         _viewerWindow.UnloadPlugin();

--- a/QuickLook/ViewerWindow.Actions.cs
+++ b/QuickLook/ViewerWindow.Actions.cs
@@ -160,6 +160,12 @@ public partial class ViewerWindow
             Debug.WriteLine(e);
         }
 
+        if (_autoReloadWatcher != null)
+        {
+            _autoReloadWatcher.Dispose();
+            _autoReloadWatcher = null;
+        }
+
         Plugin = null;
 
         _path = string.Empty;
@@ -209,6 +215,17 @@ public partial class ViewerWindow
         {
             Dispatcher.BeginInvoke(new Action(() => this.BringToFront(Topmost)), DispatcherPriority.Render);
             Show();
+        }
+
+        if (_autoReload && File.Exists(path))
+        {
+            _autoReloadWatcher?.Dispose();
+            _autoReloadWatcher = new FileSystemWatcher(Path.GetDirectoryName(path)!, Path.GetFileName(path)!)
+            {
+                NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.Size
+            };
+            _autoReloadWatcher.Changed += (_, _) => Dispatcher.Invoke(() => ViewWindowManager.GetInstance().ReloadPreview());
+            _autoReloadWatcher.EnableRaisingEvents = true;
         }
 
         //ShowWindowCaptionContainer(null, null);

--- a/QuickLook/ViewerWindow.xaml
+++ b/QuickLook/ViewerWindow.xaml
@@ -117,6 +117,11 @@
                             DockPanel.Dock="Right"
                             Style="{StaticResource CaptionButtonStyle}"
                             ToolTip="Open with XXX" />
+                    <Button x:Name="buttonReload"
+                            Content="&#xE72C;"
+                            DockPanel.Dock="Right"
+                            Style="{StaticResource CaptionButtonStyle}"
+                            ToolTip="Reload" />
                     <!--<Button x:Name="buttonOpen" DockPanel.Dock="Right"
                             Style="{StaticResource CaptionTextButtonStyle}"
                             Visibility="{Binding ActualWidth, ElementName=windowCaptionContainer, Converter={StaticResource WidthToVisibilityCollapsedConverter}}">


### PR DESCRIPTION
Summary

Introduced a new “Reload” button in the viewer window toolbar for quickly refreshing the current preview without closing the window

Added the “MW_Reload” string to the translations so the Reload button text can be localized

Implemented a ReloadPreview method in ViewWindowManager to refresh the plugin content in-place

Hooked the Reload button and added optional file monitoring for auto-reload in ViewerWindow code-behind

Allowed custom window background colors via the WindowBackgroundColor setting