### PR TITLE
Update Polish translation file

### DIFF
--- a/QuickLook/Translations.config
+++ b/QuickLook/Translations.config
@@ -418,9 +418,9 @@
     <MW_BrowseFolder>Przeglądaj {0}</MW_BrowseFolder>
     <MW_StayTop>Przypnij do ekranu</MW_StayTop>
     <MW_PreventClosing>Zablokuj zamykanie</MW_PreventClosing>
-    <MW_BrowseFolder>Przeglądaj {0}</MW_BrowseFolder>
     <MW_Open>Otwórz {0}</MW_Open>
     <MW_OpenWith>Otwórz w {0}</MW_OpenWith>
+    <MW_OpenWithMenu>Otwórz za pomocą...</MW_OpenWithMenu>
     <MW_Run>Uruchom {0}</MW_Run>
     <MW_Share>Udostępnij</MW_Share>
     <MW_Reload>Przeładuj</MW_Reload>
@@ -441,6 +441,7 @@
     <InfoPanel_File>{0} plik</InfoPanel_File>
     <InfoPanel_Files>{0} plików</InfoPanel_Files>
     <InfoPanel_FolderAndFile>({0} i {1})</InfoPanel_FolderAndFile>
+    <InfoPanel_CantPreventClosing>Anulowanie dla funkcji blokady zamykania okna nie jest wspierane</InfoPanel_CantPreventClosing>
   </pl>
   <pt-BR>
     <UI_FontFamily>Segoe UI</UI_FontFamily>


### PR DESCRIPTION
- Add missing translations for MW_OpenWithMenu and InfoPanel_CantPreventClosing
- Remove duplicate entry for MW_BrowseFolder

## Summary by Sourcery

Update Polish translation file by adding missing entries and removing duplicates

Documentation:
- Add missing Polish translations for open-with menu and info panel messages
- Remove duplicate entry for the browse-folder menu item