### PR TITLE
Allow setting of the font and font size used in the text viewer

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -237,6 +237,20 @@ These keys are also stored in `QuickLook.config`.
 - Example:
   - `<AllowDarkTheme>True</AllowDarkTheme>`
 
+### `<FontFamily>`
+- Default: default font of the current language
+- Type: `String`
+- Description: Allow setting of the font used in the text viewer.
+- Example:
+  - `<FontFamily>Cascadia Mono SemiLight</FontFamily>`
+
+### `<FontSize>`
+- Default: 14.0
+- Type: `Double`
+- Description: Allow setting of font size used in the text viewer.
+- Example:
+  - `<FontSize>13</FontSize>`
+
 ## Notes
 
 - All option names are case-sensitive and stored as XML element names under `<Settings>`.

--- a/QuickLook.Plugin/QuickLook.Plugin.TextViewer/TextViewerPanel.cs
+++ b/QuickLook.Plugin/QuickLook.Plugin.TextViewer/TextViewerPanel.cs
@@ -72,7 +72,6 @@ public partial class TextViewerPanel : TextEditor, IDisposable
 
     public TextViewerPanel()
     {
-        FontSize = SettingHelper.Get("FontSize", 14.0, "QuickLook.Plugin.TextViewer");
         ShowLineNumbers = true;
         WordWrap = true;
         IsReadOnly = true;
@@ -117,8 +116,12 @@ public partial class TextViewerPanel : TextEditor, IDisposable
 
         PreviewMouseWheel += Viewer_MouseWheel;
 
-        FontFamily = new FontFamily(SettingHelper.Get("FontFamily", TranslationHelper.Get("Editor_FontFamily",
-             domain: Assembly.GetExecutingAssembly().GetName().Name), "QuickLook.Plugin.TextViewer"));
+        FontSize = SettingHelper.Get("FontSize", 14d, "QuickLook.Plugin.TextViewer");
+        FontFamily = new FontFamily(
+            SettingHelper.Get("FontFamily",
+                failsafe: TranslationHelper.Get("Editor_FontFamily",
+                domain: Assembly.GetExecutingAssembly().GetName().Name),
+            "QuickLook.Plugin.TextViewer"));
 
         // Add a custom element generator (e.g., to truncate extremely long lines).
         TextArea.TextView.ElementGenerators.Add(new TruncateLongLines());

--- a/QuickLook.Plugin/QuickLook.Plugin.TextViewer/TextViewerPanel.cs
+++ b/QuickLook.Plugin/QuickLook.Plugin.TextViewer/TextViewerPanel.cs
@@ -72,7 +72,7 @@ public partial class TextViewerPanel : TextEditor, IDisposable
 
     public TextViewerPanel()
     {
-        FontSize = 14;
+        FontSize = SettingHelper.Get("FontSize", 14.0, "QuickLook.Plugin.TextViewer");
         ShowLineNumbers = true;
         WordWrap = true;
         IsReadOnly = true;
@@ -117,8 +117,8 @@ public partial class TextViewerPanel : TextEditor, IDisposable
 
         PreviewMouseWheel += Viewer_MouseWheel;
 
-        FontFamily = new FontFamily(TranslationHelper.Get("Editor_FontFamily",
-            domain: Assembly.GetExecutingAssembly().GetName().Name));
+        FontFamily = new FontFamily(SettingHelper.Get("FontFamily", TranslationHelper.Get("Editor_FontFamily",
+             domain: Assembly.GetExecutingAssembly().GetName().Name), "QuickLook.Plugin.TextViewer"));
 
         // Add a custom element generator (e.g., to truncate extremely long lines).
         TextArea.TextView.ElementGenerators.Add(new TruncateLongLines());

--- a/QuickLook.Plugin/QuickLook.Plugin.TextViewer/TextViewerPanel.cs
+++ b/QuickLook.Plugin/QuickLook.Plugin.TextViewer/TextViewerPanel.cs
@@ -116,7 +116,8 @@ public partial class TextViewerPanel : TextEditor, IDisposable
 
         PreviewMouseWheel += Viewer_MouseWheel;
 
-        FontSize = SettingHelper.Get("FontSize", 14d, "QuickLook.Plugin.TextViewer");
+        // Read configured font size and validate it to avoid negative or unreasonable values
+        FontSize = Math.Max(1d, Math.Min(72d, SettingHelper.Get("FontSize", 14d, "QuickLook.Plugin.TextViewer")));
         FontFamily = new FontFamily(
             SettingHelper.Get("FontFamily",
                 failsafe: TranslationHelper.Get("Editor_FontFamily",


### PR DESCRIPTION
## PR Checklist
- [x] Functionality has been tested, no obvious bugs
- [x] Code style follows project conventions
- [x] Documentation/comments updated (if applicable)

## Brief Description of Changes
Add support for the font and font size settings in the configuration file (QuickLook.Plugin.TextViewer.config).

## Related Issue (if any)
-

## Additional Notes
-

## Summary by Sourcery

Add configurable font family and font size support to the text viewer plugin via settings and documentation updates.

New Features:
- Allow configuring the text viewer font family through the plugin configuration file.
- Allow configuring the text viewer font size through the plugin configuration file.

Documentation:
- Document new FontFamily and FontSize options in OPTIONS.md.