### PR TITLE
fix: update shields.io download badge logo to 'github'

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
     <img src="https://img.shields.io/github/v/release/QL-Win/QuickLook?style=for-the-badge&logo=github&color=00C853&labelColor=000000" alt="Release">
   </a>
   <a href="https://github.com/QL-Win/QuickLook/releases">
-    <img src="https://img.shields.io/github/downloads/QL-Win/QuickLook/total?style=for-the-badge&logo=download&color=FF6D00&labelColor=000000" alt="Downloads">
+    <img src="https://img.shields.io/github/downloads/QL-Win/QuickLook/total?style=for-the-badge&logo=github&color=FF6D00&labelColor=000000" alt="Downloads">
   </a>
   <a href="https://github.com/QL-Win/QuickLook/stargazers">
     <img src="https://img.shields.io/github/stars/QL-Win/QuickLook?style=for-the-badge&logo=starship&color=FFD700&labelColor=000000" alt="Stars">


### PR DESCRIPTION
## PR Checklist
- [x] Functionality has been tested, no obvious bugs
- [x] Code style follows project conventions
- [x] Documentation/comments updated (if applicable)

## Brief Description of Changes
Please briefly describe the main changes in this PR:

## Related Issue (if any)
Please provide related issue numbers:

## Additional Notes
Add any extra notes here:

## Summary by Sourcery

Documentation:
- Adjust the downloads badge in the README to use the GitHub logo instead of the generic download icon.