### PR TITLE
Add FilePilot preview integration

### DIFF
--- a/QuickLook/Helpers/FilePilotHelper.cs
+++ b/QuickLook/Helpers/FilePilotHelper.cs
@@ -1,0 +1,256 @@
+// Copyright © 2017-2026 QL-Win Contributors
+//
+// This file is part of QuickLook program.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using QuickLook.Common.NativeMethods;
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Windows;
+using System.Windows.Automation;
+using WinFormsSendKeys = System.Windows.Forms.SendKeys;
+using WpfClipboard = System.Windows.Clipboard;
+using WpfDataObject = System.Windows.IDataObject;
+
+namespace QuickLook.Helpers;
+
+internal static class FilePilotHelper
+{
+    private const string CopyAsPathHotkey = "^+c";
+    private const int ClipboardPollIntervalMs = 5;
+    private const int ClipboardTimeoutMs = 250;
+    private const int MaxClassNameLength = 256;
+    private const string ProcessName = "FPilot";
+
+    internal static bool IsPreviewContext()
+    {
+        return IsForegroundFilePilot() && !IsTextInputFocused();
+    }
+
+    internal static bool IsForegroundFilePilot()
+    {
+        var hwnd = User32.GetForegroundWindow();
+        return hwnd != IntPtr.Zero && IsFilePilotWindow(hwnd);
+    }
+
+    internal static string GetCurrentSelection()
+    {
+        if (!IsPreviewContext())
+            return string.Empty;
+
+        var hadBackup = TryGetClipboard(out var backup);
+
+        try
+        {
+            ClearClipboard();
+            WinFormsSendKeys.SendWait(CopyAsPathHotkey);
+
+            return NormalizePath(WaitForClipboardText());
+        }
+        catch (Exception e)
+        {
+            Debug.WriteLine(e);
+            return string.Empty;
+        }
+        finally
+        {
+            RestoreClipboard(backup, hadBackup);
+        }
+    }
+
+    private static bool IsFilePilotWindow(nint hwnd)
+    {
+        try
+        {
+            User32.GetWindowThreadProcessId(hwnd, out var processId);
+            if (processId == 0)
+                return false;
+
+            using var process = Process.GetProcessById((int)processId);
+            return string.Equals(process.ProcessName, ProcessName, StringComparison.OrdinalIgnoreCase);
+        }
+        catch (Exception e)
+        {
+            Debug.WriteLine(e);
+            return false;
+        }
+    }
+
+    private static bool IsTextInputFocused()
+    {
+        return IsWin32TextInputFocused() || IsAutomationTextInputFocused();
+    }
+
+    private static bool IsWin32TextInputFocused()
+    {
+        var foregroundWindow = User32.GetForegroundWindow();
+        if (foregroundWindow == IntPtr.Zero)
+            return false;
+
+        var foregroundThread = User32.GetWindowThreadProcessId(foregroundWindow, out _);
+        var currentThread = Kernel32.GetCurrentThreadId();
+        var attached = false;
+
+        try
+        {
+            if (foregroundThread != currentThread)
+                attached = User32.AttachThreadInput(currentThread, foregroundThread, true) != IntPtr.Zero;
+
+            var focused = User32.GetFocus();
+            if (focused == IntPtr.Zero)
+                return false;
+
+            var className = GetClassName(focused);
+            return IsTextInputClass(className);
+        }
+        catch (Exception e)
+        {
+            Debug.WriteLine(e);
+            return false;
+        }
+        finally
+        {
+            if (attached)
+                User32.AttachThreadInput(currentThread, foregroundThread, false);
+        }
+    }
+
+    private static bool IsAutomationTextInputFocused()
+    {
+        try
+        {
+            var foregroundWindow = User32.GetForegroundWindow();
+            if (foregroundWindow == IntPtr.Zero)
+                return false;
+
+            User32.GetWindowThreadProcessId(foregroundWindow, out var foregroundProcessId);
+            var focused = AutomationElement.FocusedElement;
+            if (focused == null || focused.Current.ProcessId != foregroundProcessId)
+                return false;
+
+            var controlType = focused.Current.ControlType;
+            if (controlType == ControlType.Edit || controlType == ControlType.ComboBox)
+                return true;
+
+            return IsTextInputClass(focused.Current.ClassName);
+        }
+        catch (Exception e)
+        {
+            Debug.WriteLine(e);
+            return false;
+        }
+    }
+
+    private static bool IsTextInputClass(string className)
+    {
+        if (string.IsNullOrWhiteSpace(className))
+            return false;
+
+        return className.StartsWith("Edit", StringComparison.OrdinalIgnoreCase) ||
+               className.StartsWith("RichEdit", StringComparison.OrdinalIgnoreCase) ||
+               className.StartsWith("WindowsForms10.EDIT", StringComparison.OrdinalIgnoreCase) ||
+               className.StartsWith("Scintilla", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string GetClassName(nint hwnd)
+    {
+        var className = new StringBuilder(MaxClassNameLength);
+        User32.GetClassName(hwnd, className, className.Capacity);
+        return className.ToString();
+    }
+
+    private static bool TryGetClipboard(out WpfDataObject data)
+    {
+        data = null;
+
+        try
+        {
+            data = WpfClipboard.GetDataObject();
+            return data != null;
+        }
+        catch (Exception e)
+        {
+            Debug.WriteLine(e);
+            return false;
+        }
+    }
+
+    private static void ClearClipboard()
+    {
+        try
+        {
+            WpfClipboard.Clear();
+        }
+        catch (Exception e)
+        {
+            Debug.WriteLine(e);
+        }
+    }
+
+    private static void RestoreClipboard(WpfDataObject data, bool hadBackup)
+    {
+        try
+        {
+            if (hadBackup && data != null)
+                WpfClipboard.SetDataObject(data, true);
+            else
+                WpfClipboard.Clear();
+        }
+        catch (Exception e)
+        {
+            Debug.WriteLine(e);
+        }
+    }
+
+    private static string WaitForClipboardText()
+    {
+        var start = Environment.TickCount;
+
+        while (Environment.TickCount - start < ClipboardTimeoutMs)
+        {
+            try
+            {
+                if (WpfClipboard.ContainsText())
+                    return WpfClipboard.GetText();
+            }
+            catch (Exception e)
+            {
+                Debug.WriteLine(e);
+            }
+
+            Thread.Sleep(ClipboardPollIntervalMs);
+        }
+
+        return string.Empty;
+    }
+
+    private static string NormalizePath(string value)
+    {
+        var path = value?.Trim() ?? string.Empty;
+        if (path.Length == 0)
+            return string.Empty;
+
+        if (path.Contains("\r") || path.Contains("\n"))
+            path = path.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).FirstOrDefault()?.Trim() ?? string.Empty;
+
+        if (path.Length >= 2 && path[0] == '"' && path[path.Length - 1] == '"')
+            path = path.Substring(1, path.Length - 2);
+
+        return path;
+    }
+}

--- a/QuickLook/KeystrokeDispatcher.cs
+++ b/QuickLook/KeystrokeDispatcher.cs
@@ -34,6 +34,7 @@ internal class KeystrokeDispatcher : IDisposable
     private GlobalKeyboardHook _hook;
     private nint _winEventHook;
     private User32.WinEventProc _winEventProc; // keep reference to prevent GC
+    private bool _isFilePilotPreviewRequest;
     private bool _isPreviewRequest;
     private bool _spaceIsDown;
     private long _spaceHoldTick;
@@ -108,8 +109,11 @@ internal class KeystrokeDispatcher : IDisposable
         // check if the valid key is a preview request
         if (isKeyDown)
         {
-            _isPreviewRequest = NativeMethods.QuickLook.GetFocusedWindowType() !=
-                                NativeMethods.QuickLook.FocusedWindowType.Invalid;
+            var focusedWindowType = NativeMethods.QuickLook.GetFocusedWindowType();
+            _isFilePilotPreviewRequest = focusedWindowType == NativeMethods.QuickLook.FocusedWindowType.Invalid &&
+                                         FilePilotHelper.IsPreviewContext();
+            _isPreviewRequest = focusedWindowType != NativeMethods.QuickLook.FocusedWindowType.Invalid ||
+                                _isFilePilotPreviewRequest;
             _isPreviewRequest |= WindowHelper.IsForegroundWindowBelongToSelf();
         } // else (when isKeyDown is false), _isPreviewRequest retain its current state
 
@@ -126,12 +130,16 @@ internal class KeystrokeDispatcher : IDisposable
                 if (isKeyDown && e.KeyCode == Keys.Space)
                     _spaceIsDown = true;
             }
+
+            if (_isFilePilotPreviewRequest && e.KeyCode == Keys.Space)
+                e.Handled = true;
         }
 
         // when the key has been released, reset variables
         if (!isKeyDown)
         {
             _isPreviewRequest = false;
+            _isFilePilotPreviewRequest = false;
             _spaceIsDown = e.KeyCode != Keys.Space && _spaceIsDown;
         }
     }

--- a/QuickLook/ViewWindowManager.cs
+++ b/QuickLook/ViewWindowManager.cs
@@ -49,7 +49,7 @@ public class ViewWindowManager : IDisposable
 
         // if the current focus is in Desktop or explorer windows, just close the preview window and leave the task to System.
         var focus = NativeMethods.QuickLook.GetFocusedWindowType();
-        if (focus != NativeMethods.QuickLook.FocusedWindowType.Invalid)
+        if (focus != NativeMethods.QuickLook.FocusedWindowType.Invalid || FilePilotHelper.IsForegroundFilePilot())
         {
             StopFocusMonitor();
             _viewerWindow.Close();
@@ -76,7 +76,7 @@ public class ViewWindowManager : IDisposable
     public void TogglePreview(string path = null, string options = null)
     {
         if (string.IsNullOrEmpty(path))
-            path = NativeMethods.QuickLook.GetCurrentSelection();
+            path = GetCurrentSelection();
 
         if (!string.IsNullOrEmpty(options))
             InvokePreviewWithOption(path, options);
@@ -112,7 +112,7 @@ public class ViewWindowManager : IDisposable
             return;
 
         if (string.IsNullOrEmpty(path))
-            path = NativeMethods.QuickLook.GetCurrentSelection();
+            path = GetCurrentSelection();
 
         if (string.IsNullOrEmpty(path))
             return;
@@ -143,7 +143,7 @@ public class ViewWindowManager : IDisposable
     public void InvokePreview(string path = null)
     {
         if (string.IsNullOrEmpty(path))
-            path = NativeMethods.QuickLook.GetCurrentSelection();
+            path = GetCurrentSelection();
 
         if (string.IsNullOrEmpty(path))
             return;
@@ -221,6 +221,14 @@ public class ViewWindowManager : IDisposable
         _viewerWindow.UnloadPlugin();
 
         _viewerWindow.BeginShow(matchedPlugin, path, CurrentPluginFailed);
+    }
+
+    private static string GetCurrentSelection()
+    {
+        var filePilotSelection = FilePilotHelper.GetCurrentSelection();
+        return string.IsNullOrEmpty(filePilotSelection)
+            ? NativeMethods.QuickLook.GetCurrentSelection()
+            : filePilotSelection;
     }
 
     private void CurrentPluginFailed(string path, ExceptionDispatchInfo e)


### PR DESCRIPTION
## PR Checklist
- [x] Functionality has been tested, no obvious bugs
- [x] Code style follows project conventions
- [x] Documentation/comments updated (if applicable)

## Brief Description of Changes
Adds FilePilot support to QuickLook's global Space preview flow.

When `FPilot.exe` is the foreground app, QuickLook now treats it as a valid preview context, asks FilePilot to copy the selected item path, restores the clipboard, and previews that path through the existing QuickLook pipeline. This replaces the need for an external AutoHotkey script for Space preview.

## Related Issue (if any)
N/A

## Additional Notes
N/A

## Summary by Sourcery

Integrate FilePilot as a first-class preview source in QuickLook’s Space-based preview flow.

New Features:
- Add FilePilotHelper to detect FilePilot foreground windows, determine preview context, and retrieve the selected file path via simulated Copy As Path and clipboard handling.
- Allow QuickLook to trigger previews when FilePilot is the active window by treating its selection as the current preview target and closing previews appropriately in that context.

Enhancements:
- Refactor selection retrieval in ViewWindowManager to centralize logic through a GetCurrentSelection helper that falls back to existing QuickLook selection APIs.
- Extend KeystrokeDispatcher to recognize FilePilot preview requests, including distinguishing text-input focus and suppressing Space key handling in that scenario to avoid conflicts.