### PR TITLE
Add preview loading status

### DIFF
--- a/QuickLook.Common/Plugin/ContextObject.cs
+++ b/QuickLook.Common/Plugin/ContextObject.cs
@@ -32,6 +32,9 @@ public class ContextObject : INotifyPropertyChanged
     private bool _canResize = true;
     private bool _fullWindowDragging;
     private bool _isBusy;
+    private string _busyGlyph = string.Empty;
+    private string _busySubText = string.Empty;
+    private string _busyText = string.Empty;
     private string _title = string.Empty;
     private bool _titlebarAutoHide;
     private bool _titlebarBlurVisibility;
@@ -82,6 +85,45 @@ public class ContextObject : INotifyPropertyChanged
         set
         {
             _isBusy = value;
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Get or set the icon shown with the busy status text.
+    /// </summary>
+    public string BusyGlyph
+    {
+        get => _busyGlyph;
+        set
+        {
+            _busyGlyph = value;
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Get or set the status text shown with the busy indicator.
+    /// </summary>
+    public string BusyText
+    {
+        get => _busyText;
+        set
+        {
+            _busyText = value;
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Get or set the secondary status text shown with the busy indicator.
+    /// </summary>
+    public string BusySubText
+    {
+        get => _busySubText;
+        set
+        {
+            _busySubText = value;
             OnPropertyChanged();
         }
     }
@@ -243,6 +285,9 @@ public class ContextObject : INotifyPropertyChanged
         Title = string.Empty;
         // set to False to prevent showing loading icon
         IsBusy = false;
+        BusyGlyph = string.Empty;
+        BusyText = string.Empty;
+        BusySubText = string.Empty;
         PreferredSize = new Size();
         CanResize = true;
         FullWindowDragging = false;

--- a/QuickLook/Helpers/CloudFileHelper.cs
+++ b/QuickLook/Helpers/CloudFileHelper.cs
@@ -1,0 +1,116 @@
+// Copyright © 2017-2026 QL-Win Contributors
+//
+// This file is part of QuickLook program.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.IO;
+
+namespace QuickLook.Helpers;
+
+internal static class CloudFileHelper
+{
+    private const int FileAttributeOffline = 0x00001000;
+    private const int FileAttributeRecallOnOpen = 0x00040000;
+    private const int FileAttributeRecallOnDataAccess = 0x00400000;
+
+    internal static CloudFileInfo GetInfo(string path)
+    {
+        return new CloudFileInfo(IsCloudPlaceholder(path), GetProviderName(path));
+    }
+
+    internal static bool IsCloudPlaceholder(string path)
+    {
+        if (string.IsNullOrEmpty(path) || path.StartsWith("::", StringComparison.Ordinal))
+            return false;
+
+        try
+        {
+            var attributes = (int)File.GetAttributes(path);
+
+            return (attributes & FileAttributeOffline) != 0 ||
+                   (attributes & FileAttributeRecallOnOpen) != 0 ||
+                   (attributes & FileAttributeRecallOnDataAccess) != 0;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    private static string GetProviderName(string path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return string.Empty;
+
+        var normalizedPath = path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+        if (IsUnderKnownRoot(normalizedPath, Environment.GetEnvironmentVariable("OneDrive")) ||
+            IsUnderKnownRoot(normalizedPath, Environment.GetEnvironmentVariable("OneDriveConsumer")) ||
+            IsUnderKnownRoot(normalizedPath, Environment.GetEnvironmentVariable("OneDriveCommercial")) ||
+            ContainsPathPart(normalizedPath, "OneDrive"))
+            return "OneDrive";
+
+        if (ContainsPathPart(normalizedPath, "Google Drive") ||
+            ContainsPathPart(normalizedPath, "DriveFS") ||
+            ContainsPathPart(normalizedPath, "My Drive"))
+            return "Google Drive";
+
+        if (ContainsPathPart(normalizedPath, "Dropbox"))
+            return "Dropbox";
+
+        if (ContainsPathPart(normalizedPath, "iCloudDrive") ||
+            ContainsPathPart(normalizedPath, "iCloud Drive"))
+            return "iCloud Drive";
+
+        if (ContainsPathPart(normalizedPath, "Box"))
+            return "Box";
+
+        return string.Empty;
+    }
+
+    private static bool IsUnderKnownRoot(string path, string root)
+    {
+        if (string.IsNullOrWhiteSpace(path) || string.IsNullOrWhiteSpace(root))
+            return false;
+
+        var normalizedRoot = root.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+        return path.Equals(normalizedRoot, StringComparison.OrdinalIgnoreCase) ||
+               path.StartsWith(normalizedRoot + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase) ||
+               path.StartsWith(normalizedRoot + Path.AltDirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool ContainsPathPart(string path, string part)
+    {
+        return path.IndexOf(Path.DirectorySeparatorChar + part + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase) >= 0 ||
+               path.IndexOf(Path.AltDirectorySeparatorChar + part + Path.AltDirectorySeparatorChar, StringComparison.OrdinalIgnoreCase) >= 0 ||
+               path.EndsWith(Path.DirectorySeparatorChar + part, StringComparison.OrdinalIgnoreCase) ||
+               path.EndsWith(Path.AltDirectorySeparatorChar + part, StringComparison.OrdinalIgnoreCase);
+    }
+}
+
+internal sealed class CloudFileInfo
+{
+    internal CloudFileInfo(bool isPlaceholder, string providerName)
+    {
+        IsPlaceholder = isPlaceholder;
+        ProviderName = providerName ?? string.Empty;
+    }
+
+    internal bool IsPlaceholder { get; }
+
+    internal string ProviderName { get; }
+}

--- a/QuickLook/ViewWindowManager.cs
+++ b/QuickLook/ViewWindowManager.cs
@@ -22,6 +22,8 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.ExceptionServices;
+using System.Threading.Tasks;
+using System.Windows.Threading;
 
 namespace QuickLook;
 
@@ -29,7 +31,15 @@ public class ViewWindowManager : IDisposable
 {
     private static ViewWindowManager _instance;
 
+    private const int LoadingDelayMs = 150;
+    private const int SlowLoadingMs = 12000;
+    private const int TimeoutLoadingMs = 45000;
+
     private string _invokedPath = string.Empty;
+    private DispatcherTimer _loadingDelayTimer;
+    private DispatcherTimer _slowLoadingTimer;
+    private DispatcherTimer _timeoutLoadingTimer;
+    private int _previewRequestId;
     private ViewerWindow _viewerWindow;
 
     internal ViewWindowManager()
@@ -39,6 +49,7 @@ public class ViewWindowManager : IDisposable
 
     public void Dispose()
     {
+        StopLoadingTimers();
         StopFocusMonitor();
     }
 
@@ -47,10 +58,13 @@ public class ViewWindowManager : IDisposable
         if (!_viewerWindow.IsVisible)
             return;
 
+        _previewRequestId++;
+
         // if the current focus is in Desktop or explorer windows, just close the preview window and leave the task to System.
         var focus = NativeMethods.QuickLook.GetFocusedWindowType();
         if (focus != NativeMethods.QuickLook.FocusedWindowType.Invalid)
         {
+            StopLoadingTimers();
             StopFocusMonitor();
             _viewerWindow.Close();
             return;
@@ -60,6 +74,9 @@ public class ViewWindowManager : IDisposable
         if (!WindowHelper.IsForegroundWindowBelongToSelf())
             return;
 
+        _previewRequestId++;
+        StopLoadingTimers();
+
         StopFocusMonitor();
         _viewerWindow.RunAndClose();
     }
@@ -68,6 +85,9 @@ public class ViewWindowManager : IDisposable
     {
         if (!_viewerWindow.IsVisible)
             return;
+
+        _previewRequestId++;
+        StopLoadingTimers();
 
         StopFocusMonitor();
         _viewerWindow.Close();
@@ -99,6 +119,7 @@ public class ViewWindowManager : IDisposable
 
     internal void ForgetCurrentWindow()
     {
+        StopLoadingTimers();
         StopFocusMonitor();
 
         _viewerWindow.Pinned = true;
@@ -164,9 +185,9 @@ public class ViewWindowManager : IDisposable
 
         RunFocusMonitor();
 
-        var matchedPlugin = PluginManager.GetInstance().FindMatch(path);
+        var requestId = ++_previewRequestId;
 
-        BeginShowNewWindow(path, matchedPlugin);
+        BeginPreviewRequest(path, requestId, () => PluginManager.GetInstance().FindMatch(path));
     }
 
     public void InvokePluginPreview(string plugin, string path = null)
@@ -185,17 +206,14 @@ public class ViewWindowManager : IDisposable
         if (!isDirectory && !ExtensionFilterHelper.IsExtensionAllowed(path))
             return;
 
+        _invokedPath = path;
+
         RunFocusMonitor();
 
-        var matchedPlugin = PluginManager.GetInstance().LoadedPlugins.Find(p =>
-        {
-            return p.GetType().Assembly.GetName().Name == plugin;
-        });
+        var requestId = ++_previewRequestId;
 
-        if (matchedPlugin != null)
-        {
-            BeginShowNewWindow(path, matchedPlugin);
-        }
+        BeginPreviewRequest(path, requestId, () => PluginManager.GetInstance().LoadedPlugins.Find(p =>
+            p.GetType().Assembly.GetName().Name == plugin));
     }
 
     public void ReloadPreview()
@@ -203,9 +221,10 @@ public class ViewWindowManager : IDisposable
         if (!_viewerWindow.IsVisible || string.IsNullOrEmpty(_invokedPath))
             return;
 
-        var matchedPlugin = PluginManager.GetInstance().FindMatch(_invokedPath);
+        var path = _invokedPath;
+        var requestId = ++_previewRequestId;
 
-        BeginShowNewWindow(_invokedPath, matchedPlugin);
+        BeginPreviewRequest(path, requestId, () => PluginManager.GetInstance().FindMatch(path), true);
     }
 
     public void ToggleFullscreen()
@@ -218,9 +237,176 @@ public class ViewWindowManager : IDisposable
 
     private void BeginShowNewWindow(string path, IViewer matchedPlugin)
     {
-        _viewerWindow.UnloadPlugin();
+        var requestId = ++_previewRequestId;
 
-        _viewerWindow.BeginShow(matchedPlugin, path, CurrentPluginFailed);
+        BeginPreviewRequest(path, requestId, () => matchedPlugin, true);
+    }
+
+    private void BeginPreviewRequest(string path, int requestId, Func<IViewer> pluginFactory, bool showImmediately = false)
+    {
+        StopLoadingTimers();
+
+        var status = CreateLoadingStatus(path);
+        var shouldShowImmediately = showImmediately || _viewerWindow.IsVisible || status.ShowImmediately;
+
+        _viewerWindow.UnloadPlugin();
+        ScheduleLoadingStatus(path, requestId, status, shouldShowImmediately);
+        ScheduleLongRunningStatus(path, requestId, status);
+
+        Task.Run(pluginFactory).ContinueWith(task =>
+        {
+            _viewerWindow.Dispatcher.BeginInvoke(new Action(() =>
+            {
+                if (!IsCurrentPreviewRequest(path, requestId))
+                    return;
+
+                StopLoadingDelay();
+
+                if (task.IsFaulted)
+                {
+                    var exception = task.Exception?.GetBaseException() ?? new InvalidOperationException("Failed to prepare preview.");
+                    CurrentPluginFailed(path, ExceptionDispatchInfo.Capture(exception));
+                    return;
+                }
+
+                var matchedPlugin = task.Result;
+                if (matchedPlugin == null)
+                    return;
+
+                _viewerWindow.UpdateLoadingStatus(
+                    TranslationHelper.Get("MW_OpeningPreview", failsafe: "Opening preview..."),
+                    TranslationHelper.Get("MW_OpeningPreviewDetail", failsafe: "Preparing the viewer."),
+                    "\xe8e5");
+                _viewerWindow.BeginShow(matchedPlugin, path, CurrentPluginFailed);
+            }), DispatcherPriority.ContextIdle);
+        });
+    }
+
+    private bool IsCurrentPreviewRequest(string path, int requestId)
+    {
+        return requestId == _previewRequestId &&
+               string.Equals(path, _invokedPath, StringComparison.Ordinal);
+    }
+
+    private void ScheduleLoadingStatus(string path, int requestId, LoadingStatus status, bool showImmediately)
+    {
+        if (showImmediately)
+        {
+            ShowLoadingStatus(path, requestId, status);
+            return;
+        }
+
+        _loadingDelayTimer = new DispatcherTimer(DispatcherPriority.Background, _viewerWindow.Dispatcher)
+        {
+            Interval = TimeSpan.FromMilliseconds(LoadingDelayMs),
+        };
+        _loadingDelayTimer.Tick += (_, _) =>
+        {
+            StopLoadingDelay();
+            ShowLoadingStatus(path, requestId, status);
+        };
+        _loadingDelayTimer.Start();
+    }
+
+    private void ShowLoadingStatus(string path, int requestId, LoadingStatus status)
+    {
+        if (!IsCurrentPreviewRequest(path, requestId))
+            return;
+
+        _viewerWindow.BeginLoading(path, status.Text, status.DetailText, status.Glyph);
+    }
+
+    private void ScheduleLongRunningStatus(string path, int requestId, LoadingStatus initialStatus)
+    {
+        _slowLoadingTimer = new DispatcherTimer(DispatcherPriority.Background, _viewerWindow.Dispatcher)
+        {
+            Interval = TimeSpan.FromMilliseconds(SlowLoadingMs),
+        };
+        _slowLoadingTimer.Tick += (_, _) =>
+        {
+            StopTimer(ref _slowLoadingTimer);
+
+            if (!ShouldUpdateLongRunningStatus(path, requestId))
+                return;
+
+            _viewerWindow.UpdateLoadingStatus(
+                TranslationHelper.Get("MW_StillWaiting", failsafe: "Still waiting for the file..."),
+                initialStatus.IsCloud
+                    ? TranslationHelper.Get("MW_StillWaitingCloudDetail", failsafe: "The sync provider is still making it available.")
+                    : TranslationHelper.Get("MW_StillWaitingDetail", failsafe: "The selected viewer is still preparing the preview."),
+                initialStatus.IsCloud ? "\xebd3" : "\xe8a5");
+        };
+        _slowLoadingTimer.Start();
+
+        _timeoutLoadingTimer = new DispatcherTimer(DispatcherPriority.Background, _viewerWindow.Dispatcher)
+        {
+            Interval = TimeSpan.FromMilliseconds(TimeoutLoadingMs),
+        };
+        _timeoutLoadingTimer.Tick += (_, _) =>
+        {
+            StopTimer(ref _timeoutLoadingTimer);
+
+            if (!ShouldUpdateLongRunningStatus(path, requestId))
+                return;
+
+            _viewerWindow.UpdateLoadingStatus(
+                TranslationHelper.Get("MW_PreviewTakingLong", failsafe: "This is taking longer than expected."),
+                initialStatus.IsCloud
+                    ? TranslationHelper.Get("MW_PreviewTakingLongCloudDetail", failsafe: "Check your sync provider if the file does not finish downloading.")
+                    : TranslationHelper.Get("MW_PreviewTakingLongDetail", failsafe: "QuickLook is still working on this preview."),
+                "\xea84");
+        };
+        _timeoutLoadingTimer.Start();
+    }
+
+    private bool ShouldUpdateLongRunningStatus(string path, int requestId)
+    {
+        return IsCurrentPreviewRequest(path, requestId) &&
+               _viewerWindow.IsVisible &&
+               _viewerWindow.ContextObject.IsBusy;
+    }
+
+    private void StopLoadingTimers()
+    {
+        StopLoadingDelay();
+        StopTimer(ref _slowLoadingTimer);
+        StopTimer(ref _timeoutLoadingTimer);
+    }
+
+    private void StopLoadingDelay()
+    {
+        StopTimer(ref _loadingDelayTimer);
+    }
+
+    private static void StopTimer(ref DispatcherTimer timer)
+    {
+        timer?.Stop();
+        timer = null;
+    }
+
+    private static LoadingStatus CreateLoadingStatus(string path)
+    {
+        var cloudInfo = CloudFileHelper.GetInfo(path);
+        if (cloudInfo.IsPlaceholder)
+        {
+            var provider = string.IsNullOrWhiteSpace(cloudInfo.ProviderName)
+                ? TranslationHelper.Get("MW_CloudProvider", failsafe: "cloud")
+                : cloudInfo.ProviderName;
+
+            return new LoadingStatus(
+                string.Format(TranslationHelper.Get("MW_DownloadingFromProvider", failsafe: "Downloading from {0}..."), provider),
+                TranslationHelper.Get("MW_DownloadingFromProviderDetail", failsafe: "The file must be available locally before preview opens."),
+                "\xebd3",
+                true,
+                true);
+        }
+
+        return new LoadingStatus(
+            TranslationHelper.Get("MW_PreparingPreview", failsafe: "Preparing preview..."),
+            TranslationHelper.Get("MW_PreparingPreviewDetail", failsafe: "Selecting the best viewer."),
+            "\xe8a5",
+            false,
+            false);
     }
 
     private void CurrentPluginFailed(string path, ExceptionDispatchInfo e)
@@ -258,6 +444,28 @@ public class ViewWindowManager : IDisposable
             StopFocusMonitor();
             InitNewViewerWindow();
         };
+    }
+
+    private sealed class LoadingStatus
+    {
+        internal LoadingStatus(string text, string detailText, string glyph, bool isCloud, bool showImmediately)
+        {
+            Text = text;
+            DetailText = detailText;
+            Glyph = glyph;
+            IsCloud = isCloud;
+            ShowImmediately = showImmediately;
+        }
+
+        internal string Text { get; }
+
+        internal string DetailText { get; }
+
+        internal string Glyph { get; }
+
+        internal bool IsCloud { get; }
+
+        internal bool ShowImmediately { get; }
     }
 
     public static ViewWindowManager GetInstance()

--- a/QuickLook/ViewerWindow.Actions.cs
+++ b/QuickLook/ViewerWindow.Actions.cs
@@ -271,13 +271,57 @@ public partial class ViewerWindow
         _path = string.Empty;
     }
 
+    internal void BeginLoading(string path, string statusText, string detailText, string glyph)
+    {
+        _path = path;
+
+        ContextObject.Reset();
+        ContextObject.Title = Path.GetFileName(path);
+        UpdateLoadingStatus(statusText, detailText, glyph);
+        ContextObject.IsBusy = true;
+
+        var newSize = _customWindowSize != Size.Empty
+            ? _customWindowSize
+            : new Size(560, 260);
+
+        if (_customWindowSize == Size.Empty)
+            _ignoreNextWindowSizeChange = true;
+
+        PositionWindow(newSize);
+
+        ShowLoadingWindow();
+    }
+
+    internal void UpdateLoadingStatus(string statusText, string detailText, string glyph)
+    {
+        ContextObject.BusyGlyph = glyph;
+        ContextObject.BusyText = statusText;
+        ContextObject.BusySubText = detailText;
+        ContextObject.IsBusy = true;
+    }
+
+    private void ShowLoadingWindow()
+    {
+        if (!IsVisible)
+        {
+            Dispatcher.BeginInvoke(new Action(() =>
+            {
+                this.BringToFront(Topmost);
+                if (SettingHelper.Get("FocusWindowOnOpen", false))
+                    Activate();
+            }), DispatcherPriority.Render);
+            if (!SettingHelper.Get("ShowWindowTransition", true, "QuickLook"))
+                this.ShowWithoutTransition();
+            else
+                Show();
+        }
+    }
+
     internal void BeginShow(IViewer matchedPlugin, string path,
         Action<string, ExceptionDispatchInfo> exceptionHandler)
     {
         _path = path;
         Plugin = matchedPlugin;
-
-        ContextObject.Reset();
 
         // Assign monitor color profile
         ContextObject.ColorProfileName = DisplayDeviceHelper.GetMonitorColorProfileFromWindow(this);
@@ -309,7 +353,10 @@ public partial class ViewerWindow
         SetOpenWithButtonAndPath();
 
         // Revert UI changes
-        ContextObject.IsBusy = true;
+        UpdateLoadingStatus(
+            TranslationHelper.Get("MW_GeneratingPreview", failsafe: "Generating preview..."),
+            TranslationHelper.Get("MW_GeneratingPreviewDetail", failsafe: "Rendering the first preview frame."),
+            "\xe8a5");
 
         var newHeight = ContextObject.PreferredSize.Height + BorderThickness.Top + BorderThickness.Bottom +
                         (ContextObject.TitlebarOverlap ? 0 : windowCaptionContainer.Height);

--- a/QuickLook/ViewerWindow.xaml
+++ b/QuickLook/ViewerWindow.xaml
@@ -239,10 +239,54 @@
         <Grid x:Name="busyIndicatorLayer"
               Visibility="{Binding ElementName=mainWindow, Path=ContextObject.IsBusy, Converter={StaticResource BooleanToVisibilityConverter}}"
               ZIndex="200">
-            <busyDecorator:BusyDecorator x:Name="busyDecorator"
-                                         HorizontalAlignment="Center"
-                                         VerticalAlignment="Center"
-                                         IsBusyIndicatorShowing="{Binding ElementName=mainWindow, Path=ContextObject.IsBusy}" />
+            <StackPanel HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        MaxWidth="360">
+                <busyDecorator:BusyDecorator x:Name="busyDecorator"
+                                             HorizontalAlignment="Center"
+                                             VerticalAlignment="Center"
+                                             IsBusyIndicatorShowing="{Binding ElementName=mainWindow, Path=ContextObject.IsBusy}" />
+                <StackPanel Margin="0,14,0,0"
+                            HorizontalAlignment="Center"
+                            Orientation="Horizontal">
+                    <TextBlock Margin="0,0,7,0"
+                               VerticalAlignment="Center"
+                               FontFamily="{DynamicResource SymbolThemeFontFamily}"
+                               FontSize="14"
+                               Foreground="{DynamicResource WindowTextForeground}"
+                               Opacity="0.82"
+                               Text="{Binding ElementName=mainWindow, Path=ContextObject.BusyGlyph}" />
+                    <TextBlock MaxWidth="320"
+                               VerticalAlignment="Center"
+                               FontSize="13"
+                               Foreground="{DynamicResource WindowTextForeground}"
+                               FontWeight="SemiBold"
+                               Opacity="0.88"
+                               Text="{Binding ElementName=mainWindow, Path=ContextObject.BusyText}"
+                               TextAlignment="Center"
+                               TextTrimming="CharacterEllipsis"
+                               TextWrapping="NoWrap" />
+                </StackPanel>
+                <TextBlock Margin="0,7,0,0"
+                           MaxWidth="340"
+                           HorizontalAlignment="Center"
+                           FontSize="12"
+                           Foreground="{DynamicResource WindowTextForeground}"
+                           Opacity="0.7"
+                           Text="{Binding ElementName=mainWindow, Path=ContextObject.Title}"
+                           TextAlignment="Center"
+                           TextTrimming="CharacterEllipsis"
+                           TextWrapping="NoWrap" />
+                <TextBlock Margin="0,5,0,0"
+                           MaxWidth="340"
+                           HorizontalAlignment="Center"
+                           FontSize="11"
+                           Foreground="{DynamicResource WindowTextForeground}"
+                           Opacity="0.56"
+                           Text="{Binding ElementName=mainWindow, Path=ContextObject.BusySubText}"
+                           TextAlignment="Center"
+                           TextWrapping="Wrap" />
+            </StackPanel>
         </Grid>
     </Grid>
 </Window>


### PR DESCRIPTION
## PR Checklist
- [x] Functionality has been tested, no obvious bugs
- [x] Code style follows project conventions
- [x] Documentation/comments updated (if applicable)

## Brief Description of Changes

<img width="840" height="391" alt="image" src="https://github.com/user-attachments/assets/f5db0f03-6674-4136-b9d2-9ab866498c4c" />

This PR adds a visible loading/status view before a preview opens.

The main reason for this change is cloud-backed files, such as OneDrive, Google Drive, and similar sync providers. When a file is not available locally yet, pressing Space can start the provider download before QuickLook can render the preview. Previously there was no clear indication whether QuickLook received the Space command, whether the file was still downloading, or whether nothing happened.

With this change, QuickLook shows feedback while the preview is being prepared.

Added behavior:
- Shows a loading/status view before the preview opens.
- Detects cloud placeholder files and shows an immediate cloud download status.
- Displays provider-aware text where possible, for example OneDrive or Google Drive.
- Shows the filename being opened.
- Shows clearer preview phases, such as preparing, opening, and generating preview.
- Uses a short delay for normal local files to avoid flashing a loading UI for fast previews.
- Shows long-running messages if the preview takes longer than expected.
- Cancels stale loading timers/status updates when switching files or closing the preview.

## Related Issue (if any)
N/A

## Additional Notes

## Summary by Sourcery

Add a loading/status experience around preview startup, including cloud file detection and long-running feedback.

New Features:
- Show a dedicated loading view with filename and status text while a preview is being prepared.
- Detect cloud-backed placeholder files and display provider-aware download messaging before the preview opens.

Enhancements:
- Introduce timed status transitions for slow or stuck previews and cancel them when switching or closing previews.
- Refine preview lifecycle handling to avoid stale operations by tracking preview requests and centralizing loading state management in the viewer window.