### PR TITLE
Release notes improvement

### DIFF
--- a/QuickLook/Helpers/Updater.cs
+++ b/QuickLook/Helpers/Updater.cs
@@ -96,7 +96,7 @@ internal class Updater
             {
                 var json = DownloadJson("https://api.github.com/repos/QL-Win/QuickLook/releases");
 
-                var notes = "# QuickLook has been updated!\r\n";
+                var notes = "# A new version of QuickLook is available!\r\n";
 
                 var count = 0;
                 foreach (var item in json)

--- a/QuickLook/Translations.config
+++ b/QuickLook/Translations.config
@@ -256,7 +256,7 @@
     <Icon_CloseOnLostFocus>Close on Lost Focus</Icon_CloseOnLostFocus>
     <Icon_Quit>&amp;Quit</Icon_Quit>
     <Update_NoUpdate>You are now on the latest version.</Update_NoUpdate>
-    <Update_Found>QuickLook {0} is released. Click here to open the download page.</Update_Found>
+    <Update_Found>QuickLook {0} has been released. Click here to open the download page.</Update_Found>
     <Update_Error>Error occured when checking for updates: {0}</Update_Error>
     <InfoPanel_LastModified>Last modified at {0}</InfoPanel_LastModified>
     <InfoPanel_DriveSize>Capacity {0}, {1} available</InfoPanel_DriveSize>


### PR DESCRIPTION
## Brief Description of Changes
The "QuickLook has been updated" title on the release notes can lead the user to think that the program has been automatically updated.
Since updates must be done manually, telling the user that "A new version of QuickLook is available" is more accurate.
This PR also fixes a typo in the English string of the Update_Found notification.

## Summary by Sourcery

Update release notes messaging to clarify that a new QuickLook version is available rather than implying it was auto-updated.

Bug Fixes:
- Correct a typo in the English text of the update notification.

Enhancements:
- Improve release notes heading text to avoid suggesting automatic updates and better reflect manual update behavior.