### PR TITLE
Better Dark Mode & Image Viewer Toggle Fixes

### DIFF
--- a/QuickLook.Common/Helpers/SettingHelper.cs
+++ b/QuickLook.Common/Helpers/SettingHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017-2026 QL-Win Contributors
+// Copyright © 2017-2026 QL-Win Contributors
 //
 // This file is part of QuickLook program.
 //
@@ -26,6 +26,9 @@ namespace QuickLook.Common.Helpers;
 
 public static class SettingHelper
 {
+    public const string KeyAppTheme = "AppTheme";
+    public const string KeyLastCanvasTheme = "LastCanvasTheme";
+
     public static readonly string LocalDataPath =
         IsPortableVersion()
             ? Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? string.Empty,

--- a/QuickLook.Plugin/QuickLook.Plugin.ImageViewer/ImagePanel.xaml
+++ b/QuickLook.Plugin/QuickLook.Plugin.ImageViewer/ImagePanel.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="QuickLook.Plugin.ImageViewer.ImagePanel"
+<UserControl x:Class="QuickLook.Plugin.ImageViewer.ImagePanel"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:animatedImage="clr-namespace:QuickLook.Plugin.ImageViewer.AnimatedImage"
@@ -24,7 +24,7 @@
             <Rectangle.Style>
                 <Style>
                     <Style.Triggers>
-                        <DataTrigger Binding="{Binding ElementName=imagePanel, Path=Theme}" Value="{x:Static plugin:Themes.Dark}">
+                        <DataTrigger Binding="{Binding ElementName=imagePanel, Path=CanvasTheme}" Value="{x:Static plugin:Themes.Dark}">
                             <Setter Property="Rectangle.Fill">
                                 <Setter.Value>
                                     <ImageBrush AlignmentY="Top"
@@ -38,7 +38,7 @@
                                 </Setter.Value>
                             </Setter>
                         </DataTrigger>
-                        <DataTrigger Binding="{Binding ElementName=imagePanel, Path=Theme}" Value="{x:Static plugin:Themes.Light}">
+                        <DataTrigger Binding="{Binding ElementName=imagePanel, Path=CanvasTheme}" Value="{x:Static plugin:Themes.Light}">
                             <Setter Property="Rectangle.Fill">
                                 <Setter.Value>
                                     <ImageBrush AlignmentY="Top"

--- a/QuickLook.Plugin/QuickLook.Plugin.ImageViewer/ImagePanel.xaml.cs
+++ b/QuickLook.Plugin/QuickLook.Plugin.ImageViewer/ImagePanel.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017-2026 QL-Win Contributors
+// Copyright © 2017-2026 QL-Win Contributors
 //
 // This file is part of QuickLook program.
 //
@@ -107,6 +107,7 @@ public partial class ImagePanel : UserControl, INotifyPropertyChanged, IDisposab
 
         ShowMeta();
         Theme = ContextObject.Theme;
+        CanvasTheme = (Themes)SettingHelper.Get("LastCanvasTheme", (int)Theme, "QuickLook.Plugin.ImageViewer");
     }
 
     public bool ZoomWithControlKey
@@ -136,6 +137,17 @@ public partial class ImagePanel : UserControl, INotifyPropertyChanged, IDisposab
         set
         {
             ContextObject.Theme = value;
+            OnPropertyChanged();
+        }
+    }
+
+    private Themes _canvasTheme = Themes.Dark;
+    public Themes CanvasTheme
+    {
+        get => _canvasTheme;
+        set
+        {
+            _canvasTheme = value;
             OnPropertyChanged();
         }
     }
@@ -381,9 +393,9 @@ public partial class ImagePanel : UserControl, INotifyPropertyChanged, IDisposab
 
     private void OnBackgroundColourOnClick(object sender, RoutedEventArgs e)
     {
-        Theme = Theme == Themes.Dark ? Themes.Light : Themes.Dark;
+        CanvasTheme = CanvasTheme == Themes.Dark ? Themes.Light : Themes.Dark;
 
-        SettingHelper.Set("LastTheme", (int)Theme, "QuickLook.Plugin.ImageViewer");
+        SettingHelper.Set("LastCanvasTheme", (int)CanvasTheme, "QuickLook.Plugin.ImageViewer");
     }
 
     private void ShowMeta()

--- a/QuickLook.Plugin/QuickLook.Plugin.ImageViewer/ImagePanel.xaml.cs
+++ b/QuickLook.Plugin/QuickLook.Plugin.ImageViewer/ImagePanel.xaml.cs
@@ -107,7 +107,7 @@ public partial class ImagePanel : UserControl, INotifyPropertyChanged, IDisposab
 
         ShowMeta();
         Theme = ContextObject.Theme;
-        CanvasTheme = (Themes)SettingHelper.Get("LastCanvasTheme", (int)Theme, "QuickLook.Plugin.ImageViewer");
+        CanvasTheme = (Themes)SettingHelper.Get(SettingHelper.KeyLastCanvasTheme, (int)Theme, "QuickLook.Plugin.ImageViewer");
     }
 
     public bool ZoomWithControlKey
@@ -395,7 +395,7 @@ public partial class ImagePanel : UserControl, INotifyPropertyChanged, IDisposab
     {
         CanvasTheme = CanvasTheme == Themes.Dark ? Themes.Light : Themes.Dark;
 
-        SettingHelper.Set("LastCanvasTheme", (int)CanvasTheme, "QuickLook.Plugin.ImageViewer");
+        SettingHelper.Set(SettingHelper.KeyLastCanvasTheme, (int)CanvasTheme, "QuickLook.Plugin.ImageViewer");
     }
 
     private void ShowMeta()

--- a/QuickLook/App.xaml.cs
+++ b/QuickLook/App.xaml.cs
@@ -35,6 +35,13 @@ using Wpf.Ui.Violeta.Appearance;
 
 namespace QuickLook;
 
+public enum AppThemeMode
+{
+    Auto = 0,
+    Light = 1,
+    Dark = 2
+}
+
 public partial class App : Application
 {
     public static readonly string LocalDataPath = SettingHelper.LocalDataPath;
@@ -228,8 +235,8 @@ public partial class App : Application
         base.OnStartup(e);
 
         // Set initial theme based on system or user settings
-        var appTheme = SettingHelper.Get("AppTheme", 0, "QuickLook");
-        SetTheme(appTheme);
+        var appTheme = SettingHelper.Get(SettingHelper.KeyAppTheme, (int)AppThemeMode.Auto, "QuickLook");
+        SetTheme((AppThemeMode)appTheme);
 
         // Initialize MessageBox patching
         MessageBoxPatcher.Initialize();
@@ -348,14 +355,14 @@ public partial class App : Application
         PipeServerManager.GetInstance();
     }
 
-    public static void SetTheme(int theme)
+    public static void SetTheme(AppThemeMode theme)
     {
         switch (theme)
         {
-            case 1:
+            case AppThemeMode.Light:
                 ThemeManager.Apply(ApplicationTheme.Light);
                 break;
-            case 2:
+            case AppThemeMode.Dark:
                 ThemeManager.Apply(ApplicationTheme.Dark);
                 break;
             default:

--- a/QuickLook/App.xaml.cs
+++ b/QuickLook/App.xaml.cs
@@ -227,8 +227,9 @@ public partial class App : Application
         // Therefore, the time-consuming initialization code can't be placed before `OnStartup`
         base.OnStartup(e);
 
-        // Set initial theme based on system settings
-        ThemeManager.Apply(OSThemeHelper.AppsUseDarkTheme() ? ApplicationTheme.Dark : ApplicationTheme.Light);
+        // Set initial theme based on system or user settings
+        var appTheme = SettingHelper.Get("AppTheme", 0, "QuickLook");
+        SetTheme(appTheme);
 
         // Initialize MessageBox patching
         MessageBoxPatcher.Initialize();
@@ -345,5 +346,21 @@ public partial class App : Application
         ViewWindowManager.GetInstance();
         KeystrokeDispatcher.GetInstance();
         PipeServerManager.GetInstance();
+    }
+
+    public static void SetTheme(int theme)
+    {
+        switch (theme)
+        {
+            case 1:
+                ThemeManager.Apply(ApplicationTheme.Light);
+                break;
+            case 2:
+                ThemeManager.Apply(ApplicationTheme.Dark);
+                break;
+            default:
+                ThemeManager.Apply(OSThemeHelper.AppsUseDarkTheme() ? ApplicationTheme.Dark : ApplicationTheme.Light);
+                break;
+        }
     }
 }

--- a/QuickLook/TrayIconManager.cs
+++ b/QuickLook/TrayIconManager.cs
@@ -73,12 +73,12 @@ internal partial class TrayIconManager : IDisposable
                 },
                 _itemThemeCycle = new TrayMenuItem()
                 {
-                    Header = "Theme: Auto",
+                    Header = TranslationHelper.Get("Icon_ThemeAuto", failsafe: "Theme: Auto"),
                     Command = new RelayCommand(() =>
                     {
-                        var current = SettingHelper.Get("AppTheme", 0, "QuickLook");
-                        var next = (current + 1) % 3;
-                        SettingHelper.Set("AppTheme", next, "QuickLook");
+                        var current = SettingHelper.Get(SettingHelper.KeyAppTheme, (int)AppThemeMode.Auto, "QuickLook");
+                        var next = (AppThemeMode)((current + 1) % 3);
+                        SettingHelper.Set(SettingHelper.KeyAppTheme, (int)next, "QuickLook");
                         App.SetTheme(next);
                     }),
                 },
@@ -121,8 +121,10 @@ internal partial class TrayIconManager : IDisposable
         {
             _itemAutorun.IsChecked = AutoStartupHelper.IsAutorun();
             _itemCloseOnLostFocus.IsChecked = SettingHelper.Get("CloseOnLostFocus", false);
-            var theme = SettingHelper.Get("AppTheme", 0, "QuickLook");
-            _itemThemeCycle.Header = theme == 1 ? "Theme: Light" : theme == 2 ? "Theme: Dark" : "Theme: Auto";
+            var theme = (AppThemeMode)SettingHelper.Get(SettingHelper.KeyAppTheme, (int)AppThemeMode.Auto, "QuickLook");
+            _itemThemeCycle.Header = theme == AppThemeMode.Light ? TranslationHelper.Get("Icon_ThemeLight", failsafe: "Theme: Light") :
+                                     theme == AppThemeMode.Dark ? TranslationHelper.Get("Icon_ThemeDark", failsafe: "Theme: Dark") :
+                                     TranslationHelper.Get("Icon_ThemeAuto", failsafe: "Theme: Auto");
         };
     }
 

--- a/QuickLook/TrayIconManager.cs
+++ b/QuickLook/TrayIconManager.cs
@@ -38,6 +38,7 @@ internal partial class TrayIconManager : IDisposable
 
     private readonly TrayMenuItem _itemAutorun = null!;
     private readonly TrayMenuItem _itemCloseOnLostFocus = null!;
+    private readonly TrayMenuItem _itemThemeCycle = null!;
 
     private TrayIconManager()
     {
@@ -69,6 +70,17 @@ internal partial class TrayIconManager : IDisposable
                 {
                     Header = TranslationHelper.Get("Icon_OpenDataFolder"),
                     Command = new RelayCommand(() => Process.Start("explorer.exe", SettingHelper.LocalDataPath)),
+                },
+                _itemThemeCycle = new TrayMenuItem()
+                {
+                    Header = "Theme: Auto",
+                    Command = new RelayCommand(() =>
+                    {
+                        var current = SettingHelper.Get("AppTheme", 0, "QuickLook");
+                        var next = (current + 1) % 3;
+                        SettingHelper.Set("AppTheme", next, "QuickLook");
+                        App.SetTheme(next);
+                    }),
                 },
                 _itemAutorun = new TrayMenuItem()
                 {
@@ -109,6 +121,8 @@ internal partial class TrayIconManager : IDisposable
         {
             _itemAutorun.IsChecked = AutoStartupHelper.IsAutorun();
             _itemCloseOnLostFocus.IsChecked = SettingHelper.Get("CloseOnLostFocus", false);
+            var theme = SettingHelper.Get("AppTheme", 0, "QuickLook");
+            _itemThemeCycle.Header = theme == 1 ? "Theme: Light" : theme == 2 ? "Theme: Dark" : "Theme: Auto";
         };
     }
 


### PR DESCRIPTION
Overview
This pull request introduces improved dark mode support by adding a tri-state theme cycle option to the tray menu, and fixes an issue with the Image Viewer background toggle affecting the global application theme.

Changes:
1. Global Theme Tray Cycle: Added AppTheme option in SettingHelper and SetTheme method in App.xaml.cs; added tray menu item in TrayIconManager.cs to cycle Auto/Light/Dark with dynamic label.
2. Image Viewer Background Toggle Fix: Decoupled Image Viewer canvas background from global Theme; added CanvasTheme property and saved LastCanvasTheme; updated bindings in ImagePanel.xaml.

Files modified: QuickLook/App.xaml.cs; QuickLook/TrayIconManager.cs; QuickLook.Plugin.ImageViewer/ImagePanel.xaml.cs; QuickLook.Plugin.ImageViewer/ImagePanel.xaml

How to test: Run QuickLook, use tray menu to cycle theme, open image and toggle background; canvas background should change without affecting global UI.

## PR Checklist
- [x] Functionality has been tested, no obvious bugs
- [x] Code style follows project conventions
- [ ] Documentation/comments updated (if applicable)



https://github.com/user-attachments/assets/135609c7-00ef-472b-afbb-afc36e7f030d

To put it simply no one should have to go through this (the constant white flashes) at 3am in the morning 😭

## Related Issue (if any)
Please provide related issue numbers:

## Additional Notes
Add any extra notes here:

## Summary by Sourcery

Introduce a tray theme cycle and decouple the Image Viewer canvas background from the global application theme.

New Features:
- Add a tray menu option to cycle between auto, light, and dark application themes, persisting the selection across sessions.

Bug Fixes:
- Ensure toggling the Image Viewer background only changes the canvas background and no longer alters the global application theme.

Enhancements:
- Initialize the application theme from stored user preferences with a fallback to the system theme.
- Persist a separate last-used canvas theme for the Image Viewer to restore its background state on launch.