### PR TITLE
ci: pin pyTooling/Actions/releaser to a SHA instead of the r6 branch

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -70,7 +70,7 @@ jobs:
     
     - name: Update latest release
       # see https://github.com/pyTooling/Actions/tree/r6/releaser
-      uses: pyTooling/Actions/releaser@r6
+      uses: pyTooling/Actions/releaser@c58169077d7a6289af1885bb0711eb263a57727d # r6
       with:
         tag: latest
         rm: true


### PR DESCRIPTION
## What this does

`.github/workflows/msbuild.yml`'s `publish` job pins the third-party action `pyTooling/Actions/releaser` to the mutable `@r6` branch (line 73). That job holds `permissions: write-all` and passes `token: ${{ secrets.GITHUB_TOKEN }}`. This pins it to a full commit SHA instead:

```yaml
uses: pyTooling/Actions/releaser@c58169077d7a6289af1885bb0711eb263a57727d # r6
```

## Why

`@r6` is a branch (not a tag) — `pyTooling/Actions` moves it as new 6.x releases land. So whatever that branch points to at run time executes with a write-all `GITHUB_TOKEN` in scope, which could tamper with the `latest` release artifacts users download. Pinning to a commit SHA closes that moving-target window (the tj-actions/changed-files class of risk) while keeping behavior identical.

I pinned to the branch's current head commit so nothing changes functionally. `pyTooling/Actions` also publishes immutable `v6.x` tags (e.g. `v6.7.0`) if you'd prefer a version-style pin — happy to switch to that.

One-line change. (The `build` job's `microsoft/setup-msbuild@v3` holds no secret, so I left it alone.)

---

*Disclosure: I used an AI tool to help spot this and prepare the change; I verified the branch-vs-tag distinction and the pinned SHA myself and take responsibility for it.*

## Summary by Sourcery

CI:
- Update the msbuild workflow to use a commit-SHA-based reference for pyTooling/Actions/releaser rather than the r6 branch.